### PR TITLE
removing the unneeded double forward slash from the package URLs

### DIFF
--- a/src/BomGenerator.php
+++ b/src/BomGenerator.php
@@ -122,9 +122,9 @@ class BomGenerator
         }
 
         if ($component->getGroup()) {
-            $component->setPackageUrl(sprintf("pkg://composer/%s/%s@%s", $component->getGroup(), $component->getName(), $component->getVersion()));
+            $component->setPackageUrl(sprintf("pkg:composer/%s/%s@%s", $component->getGroup(), $component->getName(), $component->getVersion()));
         } else {
-            $component->setPackageUrl(sprintf("pkg://composer/%s@%s", $component->getName(), $component->getVersion()));
+            $component->setPackageUrl(sprintf("pkg:composer/%s@%s", $component->getName(), $component->getVersion()));
         }
 
         return $component;

--- a/tests/BomGeneratorTest.php
+++ b/tests/BomGeneratorTest.php
@@ -122,7 +122,7 @@ class BomGeneratorTest extends TestCase
         $this->assertContains("MIT", $component->getLicenses());
         $this->assertArrayHasKey("SHA-1", $component->getHashes());
         $this->assertEquals("7e240de74fb1ed08fa08d38063f6a6a91462a815", $component->getHashes()["SHA-1"]);
-        $this->assertEquals("pkg://composer/vendorName/packageName@6.6.6", $component->getPackageUrl());
+        $this->assertEquals("pkg:composer/vendorName/packageName@6.6.6", $component->getPackageUrl());
     }
 
     public function testBuildComponentWithoutVendor() 
@@ -140,7 +140,7 @@ class BomGeneratorTest extends TestCase
         $this->assertNull($component->getDescription());
         $this->assertEmpty($component->getLicenses());
         $this->assertEmpty($component->getHashes());
-        $this->assertEquals("pkg://composer/packageName@1.0", $component->getPackageUrl());
+        $this->assertEquals("pkg:composer/packageName@1.0", $component->getPackageUrl());
     }
 
     public function testBuildComponentWithoutName() 


### PR DESCRIPTION
Fixes #6 

The corresponding tests have been adjusted and are passing.