### PR TITLE
fix requirement of ext-dom

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         "composer-plugin-api": "^1.0 || ^2.0"
     },
     "require-dev": {
+        "ext-dom": "*",
         "phpunit/phpunit": ">=5.0 <7.0",
         "composer/composer": "^2.0"
     },


### PR DESCRIPTION
class `DOMDocument` is used in `BomXmlWriterTest`
but it was forgotten to be a dev-dependency in composer.