### PR TITLE
php-cs-fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 $header = <<<'EOF'
 This file is part of the CycloneDX PHP Composer Plugin.
@@ -22,7 +24,6 @@ EOF;
 $finder = PhpCsFixer\Finder::create()
     ->in(__DIR__.'/src')
     ->in(__DIR__.'/tests')
-    ->append([__FILE__])
 ;
 
 $config = new PhpCsFixer\Config();
@@ -32,7 +33,7 @@ return $config
     ->setRules([
         '@PHP71Migration' => true,
         '@Symfony' => true,
-        # 'declare_strict_types' => true, # @TODO have this enabled via issue#39
+        // 'declare_strict_types' => true, // @TODO have this enabled via issue#39
         'phpdoc_order' => true,
         'header_comment' => ['header' => $header],
     ])

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,0 +1,41 @@
+<?php declare(strict_types=1);
+
+$header = <<<'EOF'
+This file is part of the CycloneDX PHP Composer Plugin.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+Copyright (c) Steve Springett. All Rights Reserved.
+EOF;
+
+$finder = PhpCsFixer\Finder::create()
+    ->in(__DIR__.'/src')
+    ->in(__DIR__.'/tests')
+    ->append([__FILE__])
+;
+
+$config = new PhpCsFixer\Config();
+
+return $config
+    ->setUsingCache(true)
+    ->setRules([
+        '@PHP71Migration' => true,
+        '@Symfony' => true,
+        # 'declare_strict_types' => true, # @TODO have this enabled via issue#39
+        'phpdoc_order' => true,
+        'header_comment' => ['header' => $header],
+    ])
+    ->setRiskyAllowed(true)
+    ->setFinder($finder)
+;

--- a/.psalm/baseline-lowest.xml
+++ b/.psalm/baseline-lowest.xml
@@ -4,9 +4,8 @@
     <InvalidDocblock occurrences="1">
       <code>public function readLicenses($package)</code>
     </InvalidDocblock>
-    <MissingParamType occurrences="2">
+    <MissingParamType occurrences="1">
       <code>$package</code>
-      <code>$packageVersion</code>
     </MissingParamType>
     <MissingReturnType occurrences="1">
       <code>readLicenses</code>
@@ -19,17 +18,17 @@
       <code>$packageVersion</code>
       <code>$packageVersion</code>
       <code>$packageVersion</code>
-      <code>$package["description"]</code>
-      <code>$package["dist"]</code>
-      <code>$package["name"]</code>
+      <code>$package['description']</code>
+      <code>$package['dist']</code>
+      <code>$package['name']</code>
       <code>$packages</code>
       <code>$packagesDev</code>
       <code>$this-&gt;readLicenses($package)</code>
     </MixedArgument>
     <MixedArrayAccess occurrences="3">
-      <code>$package["license"]</code>
-      <code>$package["name"]</code>
-      <code>$package["type"]</code>
+      <code>$package['license']</code>
+      <code>$package['name']</code>
+      <code>$package['type']</code>
     </MixedArrayAccess>
     <MixedAssignment occurrences="4">
       <code>$licenseData</code>
@@ -38,18 +37,18 @@
       <code>$packagesDev</code>
     </MixedAssignment>
     <MixedInferredReturnType occurrences="1">
-      <code>string</code>
+      <code>string|null</code>
     </MixedInferredReturnType>
     <MixedOperand occurrences="2">
-      <code>$package["name"]</code>
-      <code>$package["name"]</code>
+      <code>$package['name']</code>
+      <code>$package['name']</code>
     </MixedOperand>
     <MixedReturnStatement occurrences="1">
       <code>$packageVersion</code>
     </MixedReturnStatement>
-    <NullableReturnStatement occurrences="1">
-      <code>null</code>
-    </NullableReturnStatement>
+    <PossiblyNullArgument occurrences="1">
+      <code>$this-&gt;normalizeVersion($package['version'])</code>
+    </PossiblyNullArgument>
   </file>
   <file src="src/BomXmlWriter.php">
     <MissingReturnType occurrences="2">
@@ -77,7 +76,7 @@
   </file>
   <file src="src/ComposerCommandProvider.php">
     <InvalidReturnStatement occurrences="1">
-      <code>array(new MakeBomCommand)</code>
+      <code>[new MakeBomCommand()]</code>
     </InvalidReturnStatement>
     <InvalidReturnType occurrences="2">
       <code>execute</code>
@@ -97,7 +96,7 @@
       <code>getOption</code>
       <code>getOption</code>
       <code>getOption</code>
-      <code>new MakeBomCommand</code>
+      <code>new MakeBomCommand()</code>
       <code>setName</code>
     </MissingThrowsDocblock>
     <MixedArgument occurrences="12">
@@ -176,7 +175,7 @@
       <code>validate</code>
     </MissingReturnType>
     <MissingThrowsDocblock occurrences="1">
-      <code>throw new RuntimeException('Missing license file in ' . $file);</code>
+      <code>throw new RuntimeException('Missing license file in '.$file);</code>
     </MissingThrowsDocblock>
     <MixedArgument occurrences="3">
       <code>$identifier</code>

--- a/.psalm/baseline-stable.xml
+++ b/.psalm/baseline-stable.xml
@@ -4,9 +4,8 @@
     <InvalidDocblock occurrences="1">
       <code>public function readLicenses($package)</code>
     </InvalidDocblock>
-    <MissingParamType occurrences="2">
+    <MissingParamType occurrences="1">
       <code>$package</code>
-      <code>$packageVersion</code>
     </MissingParamType>
     <MissingReturnType occurrences="1">
       <code>readLicenses</code>
@@ -19,17 +18,17 @@
       <code>$packageVersion</code>
       <code>$packageVersion</code>
       <code>$packageVersion</code>
-      <code>$package["description"]</code>
-      <code>$package["dist"]</code>
-      <code>$package["name"]</code>
+      <code>$package['description']</code>
+      <code>$package['dist']</code>
+      <code>$package['name']</code>
       <code>$packages</code>
       <code>$packagesDev</code>
       <code>$this-&gt;readLicenses($package)</code>
     </MixedArgument>
     <MixedArrayAccess occurrences="3">
-      <code>$package["license"]</code>
-      <code>$package["name"]</code>
-      <code>$package["type"]</code>
+      <code>$package['license']</code>
+      <code>$package['name']</code>
+      <code>$package['type']</code>
     </MixedArrayAccess>
     <MixedAssignment occurrences="4">
       <code>$licenseData</code>
@@ -38,18 +37,18 @@
       <code>$packagesDev</code>
     </MixedAssignment>
     <MixedInferredReturnType occurrences="1">
-      <code>string</code>
+      <code>string|null</code>
     </MixedInferredReturnType>
     <MixedOperand occurrences="2">
-      <code>$package["name"]</code>
-      <code>$package["name"]</code>
+      <code>$package['name']</code>
+      <code>$package['name']</code>
     </MixedOperand>
     <MixedReturnStatement occurrences="1">
       <code>$packageVersion</code>
     </MixedReturnStatement>
-    <NullableReturnStatement occurrences="1">
-      <code>null</code>
-    </NullableReturnStatement>
+    <PossiblyNullArgument occurrences="1">
+      <code>$this-&gt;normalizeVersion($package['version'])</code>
+    </PossiblyNullArgument>
   </file>
   <file src="src/BomXmlWriter.php">
     <MissingReturnType occurrences="2">
@@ -93,7 +92,7 @@
       <code>getOption</code>
       <code>getOption</code>
       <code>getOption</code>
-      <code>new MakeBomCommand</code>
+      <code>new MakeBomCommand()</code>
       <code>setName</code>
     </MissingThrowsDocblock>
     <MixedArgument occurrences="12">
@@ -175,7 +174,7 @@
       <code>validate</code>
     </MissingReturnType>
     <MissingThrowsDocblock occurrences="1">
-      <code>throw new RuntimeException('Missing license file in ' . $file);</code>
+      <code>throw new RuntimeException('Missing license file in '.$file);</code>
     </MissingThrowsDocblock>
     <MixedArgument occurrences="3">
       <code>$identifier</code>

--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,7 @@
         "dev-setup": [
             "@composer -dtools/composer-require-checker install",
             "@composer -dtools/composer-unused install",
+            "@composer -dtools/php-cs-fixer install",
             "@composer -dtools/psalm install",
             "@composer install"
         ],
@@ -54,20 +55,25 @@
             "@composer validate",
             "@test:psalm",
             "@test:phpunit",
+            "@test:cs-fixer",
             "@test:composer-unused",
             "@test:composer-require-checker"
         ],
         "test:phpunit" : "@php -d zend.assertions=1 -d assert.exception=1 -d display_errors=On -d error_reporting=-1 -d log_errors_max_len=0 -d memory_limit=-1 vendor/phpunit/phpunit/phpunit",
         "test:psalm": "@php tools/psalm/vendor/vimeo/psalm/psalm",
+        "test:cs-fixer": "@php tools/php-cs-fixer/vendor/friendsofphp/php-cs-fixer/php-cs-fixer fix --dry-run --diff-format=udiff",
         "test:composer-unused": "@php tools/composer-unused/vendor/icanhazstring/composer-unused/bin/composer-unused --excludeDir=tools",
-        "test:composer-require-checker": "@php tools/composer-require-checker/vendor/maglnet/composer-require-checker/bin/composer-require-checker"
+        "test:composer-require-checker": "@php tools/composer-require-checker/vendor/maglnet/composer-require-checker/bin/composer-require-checker",
+        "cs-fix": "@php tools/php-cs-fixer/vendor/friendsofphp/php-cs-fixer/php-cs-fixer fix --diff-format=udiff"
     },
     "scripts-descriptions": {
         "dev-setup": "Install dev-requirements and tools.",
         "test": "Run all tests!",
         "test:phpunit": "Run tests with PHPUnit.",
         "test:psalm": "Run static code analysis with Psalm.",
+        "test:cs-fixer": "Test coding standards with PHP-CS-fixer.",
         "test:composer-unused": "Test compoer requirements with composer-unused.",
-        "test:composer-require-checker": "Test compoer requirements with composer-require-checker."
+        "test:composer-require-checker": "Test compoer requirements with composer-require-checker.",
+        "cs-fix": "Fix files according to coding standards."
     }
 }

--- a/src/BomGenerator.php
+++ b/src/BomGenerator.php
@@ -33,38 +33,38 @@ use UnexpectedValueException;
  */
 class BomGenerator
 {
-
     /**
      * @var OutputInterface
      */
     private $output;
 
-    function __construct(OutputInterface $output)
+    public function __construct(OutputInterface $output)
     {
         $this->output = $output;
     }
 
     /**
-     * @param array $lockData Composer's lockData to generate a BOM for
-     * @param bool $excludeDev Exclude Dev dependencies
-     * @param bool $excludePlugins Exclude composer plugins
+     * @param array $lockData       Composer's lockData to generate a BOM for
+     * @param bool  $excludeDev     Exclude Dev dependencies
+     * @param bool  $excludePlugins Exclude composer plugins
+     *
      * @return Bom The resulting BOM
      */
     public function generateBom(array $lockData, $excludeDev, $excludePlugins)
     {
-        $packages = $lockData["packages"];
-        $packagesDev = $lockData["packages-dev"];
+        $packages = $lockData['packages'];
+        $packagesDev = $lockData['packages-dev'];
 
         if (!$excludeDev) {
             $packages = array_merge($packages, $packagesDev);
         } else {
-            $this->output->writeln("<warning>Dev dependencies will be skipped</warning>");
+            $this->output->writeln('<warning>Dev dependencies will be skipped</warning>');
         }
 
-        $components = array();
+        $components = [];
         foreach ($packages as &$package) {
-            if ($package["type"] === "composer-plugin" && $excludePlugins) {
-                $this->output->writeln("<warning>Skipping plugin " . $package["name"] . "</warning>");
+            if ('composer-plugin' === $package['type'] && $excludePlugins) {
+                $this->output->writeln('<warning>Skipping plugin '.$package['name'].'</warning>');
                 continue;
             }
 
@@ -76,55 +76,57 @@ class BomGenerator
 
     /**
      * @param array $package The lockData's package data to build a component from
-     * @return Component The resulting component
+     *
      * @throws UnexpectedValueException When the given package does not provide a name or version
+     *
+     * @return Component The resulting component
      */
     public function buildComponent(array $package)
     {
-        $component = new Component;
+        $component = new Component();
 
-        if (array_key_exists("name", $package) && $package["name"]) {
+        if (array_key_exists('name', $package) && $package['name']) {
             // Composer requires published packages to be named like <vendor>/<packageName>.
             // Because this is a loose requirement that doesn't apply to "internal" packages,
             // we need to consider that the vendor name may be omitted.
             // See https://getcomposer.org/doc/04-schema.md#name
-            $splittedName = explode("/", $package["name"], 2);
+            $splittedName = explode('/', $package['name'], 2);
             $splittedNameCount = count($splittedName);
-            if ($splittedNameCount == 2) {
+            if (2 == $splittedNameCount) {
                 $component->setGroup($splittedName[0]);
                 $component->setName($splittedName[1]);
             } else {
                 $component->setName($splittedName[0]);
             }
         } else {
-            throw new UnexpectedValueException("Encountered package without name: " . json_encode($package));
+            throw new UnexpectedValueException('Encountered package without name: '.json_encode($package));
         }
 
-        if (array_key_exists("version", $package) && $package["version"]) {
-            $component->setVersion($this->normalizeVersion($package["version"]));
+        if (array_key_exists('version', $package) && $package['version']) {
+            $component->setVersion($this->normalizeVersion($package['version']));
         } else {
-            throw new UnexpectedValueException("Encountered package without version: " . $package["name"]);
+            throw new UnexpectedValueException('Encountered package without version: '.$package['name']);
         }
 
-        if (array_key_exists("description", $package) && $package["description"]) {
-            $component->setDescription($package["description"]);
+        if (array_key_exists('description', $package) && $package['description']) {
+            $component->setDescription($package['description']);
         }
 
         // https://getcomposer.org/doc/04-schema.md#type
-        $component->setType("library");
+        $component->setType('library');
 
         $component->setLicenses($this->readLicenses($package));
 
-        if (array_key_exists("dist", $package) && array_key_exists("shasum", $package["dist"]) && $package["dist"]["shasum"]) {
-            $component->setHashes(array("SHA-1" => $package["dist"]["shasum"]));
+        if (array_key_exists('dist', $package) && array_key_exists('shasum', $package['dist']) && $package['dist']['shasum']) {
+            $component->setHashes(['SHA-1' => $package['dist']['shasum']]);
         } else {
-            $component->setHashes(array());
+            $component->setHashes([]);
         }
 
         if ($component->getGroup()) {
-            $component->setPackageUrl(sprintf("pkg:composer/%s/%s@%s", $component->getGroup(), $component->getName(), $component->getVersion()));
+            $component->setPackageUrl(sprintf('pkg:composer/%s/%s@%s', $component->getGroup(), $component->getName(), $component->getVersion()));
         } else {
-            $component->setPackageUrl(sprintf("pkg:composer/%s@%s", $component->getName(), $component->getVersion()));
+            $component->setPackageUrl(sprintf('pkg:composer/%s@%s', $component->getName(), $component->getVersion()));
         }
 
         return $component;
@@ -138,46 +140,50 @@ class BomGenerator
      * vs https://ossindex.sonatype.org/component/pkg:composer/phpmailer/phpmailer@6.0.7.
      *
      * @param mixed $packageVersion The version to normalize
-     * @return null|string The normalized version
+     *
+     * @return string|null The normalized version
      */
     private function normalizeVersion($packageVersion)
     {
         if (!$packageVersion) {
             return null;
         }
-        if (substr_compare($packageVersion, "v", 0, 1) === 0) {
+        if (0 === substr_compare($packageVersion, 'v', 0, 1)) {
             return substr($packageVersion, 1, strlen($packageVersion));
         }
+
         return $packageVersion;
     }
 
     /**
-     * See https://getcomposer.org/doc/04-schema.md#license
+     * See https://getcomposer.org/doc/04-schema.md#license.
      *
      * @param array
+     *
      * @return array
      */
     public function readLicenses($package)
     {
-        if (!array_key_exists("license", $package) || !$package["license"]) {
-            return array();
+        if (!array_key_exists('license', $package) || !$package['license']) {
+            return [];
         }
 
-        $licenseData = $package["license"];
+        $licenseData = $package['license'];
         if (is_string($licenseData)) {
             if (preg_match("/\((([\w\.\-]+)(\ or\ |\ and\ )?)+\)/", $licenseData)) {
                 // Conjunctive or disjunctive license provided as string
                 $licenses = preg_split("/[\(\)]/", $licenseData, -1, PREG_SPLIT_NO_EMPTY);
+
                 return preg_split("/(\ or\ |\ and\ )/", $licenses[0], -1, PREG_SPLIT_NO_EMPTY);
             }
-                // A single license provided as string
-            return array($licenseData);
-
+            // A single license provided as string
+            return [$licenseData];
         }
         if (is_array($licenseData)) {
             // Disjunctive license provided as array
             return $licenseData;
         }
+
         return [];
     }
 }

--- a/src/BomGenerator.php
+++ b/src/BomGenerator.php
@@ -28,10 +28,10 @@ use UnexpectedValueException;
 
 /**
  * Generates BOMs based on Composer's lockData.
- * 
+ *
  * @author nscuro
  */
-class BomGenerator 
+class BomGenerator
 {
 
     /**
@@ -39,7 +39,7 @@ class BomGenerator
      */
     private $output;
 
-    function __construct(OutputInterface &$output) 
+    function __construct(OutputInterface $output)
     {
         $this->output = $output;
     }
@@ -68,7 +68,7 @@ class BomGenerator
                 continue;
             }
 
-            array_push($components, $this->buildComponent($package));
+            $components[] = $this->buildComponent($package);
         }
 
         return new Bom($components);
@@ -95,7 +95,7 @@ class BomGenerator
                 $component->setName($splittedName[1]);
             } else {
                 $component->setName($splittedName[0]);
-            }   
+            }
         } else {
             throw new UnexpectedValueException("Encountered package without name: " . json_encode($package));
         }
@@ -109,7 +109,7 @@ class BomGenerator
         if (array_key_exists("description", $package) && $package["description"]) {
             $component->setDescription($package["description"]);
         }
-        
+
         // https://getcomposer.org/doc/04-schema.md#type
         $component->setType("library");
 
@@ -133,18 +133,19 @@ class BomGenerator
     /**
      * Versions of Composer packages may be prefixed with "v".
      * This prefix appears to be problematic for CPE and PURL matching and thus is removed here.
-     * 
+     *
      * See for example https://ossindex.sonatype.org/component/pkg:composer/phpmailer/phpmailer@v6.0.7
      * vs https://ossindex.sonatype.org/component/pkg:composer/phpmailer/phpmailer@6.0.7.
-     * 
-     * @param $packageVersion The version to normalize
-     * @return string The normalized version
+     *
+     * @param mixed $packageVersion The version to normalize
+     * @return null|string The normalized version
      */
-    private function normalizeVersion($packageVersion) 
+    private function normalizeVersion($packageVersion)
     {
         if (!$packageVersion) {
             return null;
-        } else if (substr_compare($packageVersion, "v", 0, 1) === 0) {
+        }
+        if (substr_compare($packageVersion, "v", 0, 1) === 0) {
             return substr($packageVersion, 1, strlen($packageVersion));
         }
         return $packageVersion;
@@ -152,7 +153,7 @@ class BomGenerator
 
     /**
      * See https://getcomposer.org/doc/04-schema.md#license
-     * 
+     *
      * @param array
      * @return array
      */
@@ -168,13 +169,15 @@ class BomGenerator
                 // Conjunctive or disjunctive license provided as string
                 $licenses = preg_split("/[\(\)]/", $licenseData, -1, PREG_SPLIT_NO_EMPTY);
                 return preg_split("/(\ or\ |\ and\ )/", $licenses[0], -1, PREG_SPLIT_NO_EMPTY);
-            } else {
-                // A single license provided as string
-                return array($licenseData);
             }
-        } else if (is_array($licenseData)) {
+                // A single license provided as string
+            return array($licenseData);
+
+        }
+        if (is_array($licenseData)) {
             // Disjunctive license provided as array
             return $licenseData;
         }
+        return [];
     }
 }

--- a/src/BomJsonWriter.php
+++ b/src/BomJsonWriter.php
@@ -22,16 +22,15 @@
 namespace CycloneDX;
 
 use CycloneDX\Model\Bom;
-use CycloneDX\Model\Component;
 
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Writes BOMs in JSON format.
- * 
+ *
  * @author nscuro
  */
-class BomJsonWriter 
+class BomJsonWriter
 {
 
     /**
@@ -39,7 +38,7 @@ class BomJsonWriter
      */
     private $output;
 
-    function __construct(OutputInterface &$output) {
+    function __construct(OutputInterface $output) {
         $this->output = $output;
     }
 
@@ -47,7 +46,7 @@ class BomJsonWriter
      * @param Bom $bom The BOM to write
      * @return string The BOM as JSON formatted string
      */
-    public function writeBom(Bom $bom) 
+    public function writeBom(Bom $bom)
     {
         $jsonBom = [
             "bomFormat" => "CycloneDX",

--- a/src/BomJsonWriter.php
+++ b/src/BomJsonWriter.php
@@ -22,7 +22,6 @@
 namespace CycloneDX;
 
 use CycloneDX\Model\Bom;
-
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -32,30 +31,30 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class BomJsonWriter
 {
-
     /**
      * @var OutputInterface
      */
     private $output;
 
-    function __construct(OutputInterface $output) {
+    public function __construct(OutputInterface $output)
+    {
         $this->output = $output;
     }
 
     /**
      * @param Bom $bom The BOM to write
+     *
      * @return string The BOM as JSON formatted string
      */
     public function writeBom(Bom $bom)
     {
         $jsonBom = [
-            "bomFormat" => "CycloneDX",
-            "specVersion" => "1.2",
-            "version" => 1,
-            "components" => $bom->getComponents(),
+            'bomFormat' => 'CycloneDX',
+            'specVersion' => '1.2',
+            'version' => 1,
+            'components' => $bom->getComponents(),
         ];
 
         return json_encode($jsonBom, JSON_PRETTY_PRINT);
     }
-
 }

--- a/src/BomXmlWriter.php
+++ b/src/BomXmlWriter.php
@@ -24,7 +24,6 @@ namespace CycloneDX;
 use CycloneDX\Model\Bom;
 use CycloneDX\Model\Component;
 use CycloneDX\Spdx\XmlLicense;
-
 use Symfony\Component\Console\Output\OutputInterface;
 use XMLWriter;
 
@@ -35,31 +34,32 @@ use XMLWriter;
  */
 class BomXmlWriter
 {
-
     /**
      * @var OutputInterface
      */
     private $output;
 
-    function __construct(OutputInterface $output) {
+    public function __construct(OutputInterface $output)
+    {
         $this->output = $output;
     }
 
     /**
      * @param Bom $bom The BOM to write
+     *
      * @return string The BOM as XML formatted string
      */
     public function writeBom(Bom $bom)
     {
-        $xmlWriter = new XMLWriter;
+        $xmlWriter = new XMLWriter();
         $xmlWriter->openMemory();
         $xmlWriter->setIndent(true);
-        $xmlWriter->setIndentString("    ");
+        $xmlWriter->setIndentString('    ');
 
-        $xmlWriter->startDocument("1.0", "utf-8");
-        $xmlWriter->startElementNs(null, "bom", "http://cyclonedx.org/schema/bom/1.1");
+        $xmlWriter->startDocument('1.0', 'utf-8');
+        $xmlWriter->startElementNs(null, 'bom', 'http://cyclonedx.org/schema/bom/1.1');
 
-        $xmlWriter->startElement("components");
+        $xmlWriter->startElement('components');
         foreach ($bom->getComponents() as $component) {
             $this->writeComponent($xmlWriter, $component);
         }
@@ -67,6 +67,7 @@ class BomXmlWriter
 
         $xmlWriter->endElement(); // bom
         $xmlWriter->endDocument();
+
         return $xmlWriter->outputMemory();
     }
 
@@ -76,28 +77,28 @@ class BomXmlWriter
      */
     private function writeComponent(XMLWriter $xmlWriter, Component $component)
     {
-        $xmlWriter->startElement("component");
+        $xmlWriter->startElement('component');
 
-        $xmlWriter->startAttribute("type");
+        $xmlWriter->startAttribute('type');
         $xmlWriter->text($component->getType());
         $xmlWriter->endAttribute();
 
         if ($component->getGroup()) {
-            $this->writeTextElement($xmlWriter, "group", $component->getGroup());
+            $this->writeTextElement($xmlWriter, 'group', $component->getGroup());
         }
-        $this->writeTextElement($xmlWriter, "name", $component->getName());
-        $this->writeTextElement($xmlWriter, "version", $component->getVersion());
+        $this->writeTextElement($xmlWriter, 'name', $component->getName());
+        $this->writeTextElement($xmlWriter, 'version', $component->getVersion());
 
         if ($component->getDescription()) {
-            $this->writeTextElement($xmlWriter, "description", $component->getDescription());
+            $this->writeTextElement($xmlWriter, 'description', $component->getDescription());
         }
 
         if ($component->getHashes()) {
-            $xmlWriter->startElement("hashes");
+            $xmlWriter->startElement('hashes');
             foreach ($component->getHashes() as $hashType => $hashValue) {
-                $xmlWriter->startElement("hash");
+                $xmlWriter->startElement('hash');
 
-                $xmlWriter->startAttribute("alg");
+                $xmlWriter->startAttribute('alg');
                 $xmlWriter->text($hashType);
                 $xmlWriter->endAttribute();
 
@@ -108,14 +109,14 @@ class BomXmlWriter
         }
 
         if ($component->getLicenses()) {
-            $xmlWriter->startElement("licenses");
+            $xmlWriter->startElement('licenses');
             $spdxLicense = new XmlLicense();
             foreach ($component->getLicenses() as &$license) {
-                $xmlWriter->startElement("license");
+                $xmlWriter->startElement('license');
                 if ($spdxLicense->validate($license)) {
-                    $this->writeTextElement($xmlWriter, "id", $spdxLicense->getLicense($license));
+                    $this->writeTextElement($xmlWriter, 'id', $spdxLicense->getLicense($license));
                 } else {
-                    $this->writeTextElement($xmlWriter, "name", $license);
+                    $this->writeTextElement($xmlWriter, 'name', $license);
                 }
                 $xmlWriter->endElement(); // license
             }
@@ -124,16 +125,16 @@ class BomXmlWriter
         }
 
         if ($component->getPackageUrl()) {
-            $this->writeTextElement($xmlWriter, "purl", $component->getPackageUrl());
+            $this->writeTextElement($xmlWriter, 'purl', $component->getPackageUrl());
         }
 
         $xmlWriter->endElement(); // component
     }
 
     /**
-     * @param XMLWriter $xmlWriter The XMLWriter instance to use
-     * @param string $elementName Name of the element
-     * @param string $elementText Text of the element
+     * @param XMLWriter $xmlWriter   The XMLWriter instance to use
+     * @param string    $elementName Name of the element
+     * @param string    $elementText Text of the element
      */
     private function writeTextElement(XMLWriter $xmlWriter, $elementName, $elementText)
     {
@@ -141,5 +142,4 @@ class BomXmlWriter
         $xmlWriter->text($elementText);
         $xmlWriter->endElement();
     }
-
 }

--- a/src/BomXmlWriter.php
+++ b/src/BomXmlWriter.php
@@ -30,10 +30,10 @@ use XMLWriter;
 
 /**
  * Writes BOMs in XML format.
- * 
+ *
  * @author nscuro
  */
-class BomXmlWriter 
+class BomXmlWriter
 {
 
     /**
@@ -41,7 +41,7 @@ class BomXmlWriter
      */
     private $output;
 
-    function __construct(OutputInterface &$output) {
+    function __construct(OutputInterface $output) {
         $this->output = $output;
     }
 
@@ -49,7 +49,7 @@ class BomXmlWriter
      * @param Bom $bom The BOM to write
      * @return string The BOM as XML formatted string
      */
-    public function writeBom(Bom $bom) 
+    public function writeBom(Bom $bom)
     {
         $xmlWriter = new XMLWriter;
         $xmlWriter->openMemory();
@@ -60,7 +60,7 @@ class BomXmlWriter
         $xmlWriter->startElementNs(null, "bom", "http://cyclonedx.org/schema/bom/1.1");
 
         $xmlWriter->startElement("components");
-        foreach ($bom->getComponents() as &$component) {
+        foreach ($bom->getComponents() as $component) {
             $this->writeComponent($xmlWriter, $component);
         }
         $xmlWriter->endElement(); // components
@@ -74,7 +74,7 @@ class BomXmlWriter
      * @param XMLWriter $xmlWriter The XMLWriter instance to use
      * @param Component $component The component to write
      */
-    private function writeComponent(XMLWriter $xmlWriter, Component $component) 
+    private function writeComponent(XMLWriter $xmlWriter, Component $component)
     {
         $xmlWriter->startElement("component");
 
@@ -96,11 +96,11 @@ class BomXmlWriter
             $xmlWriter->startElement("hashes");
             foreach ($component->getHashes() as $hashType => $hashValue) {
                 $xmlWriter->startElement("hash");
-                
+
                 $xmlWriter->startAttribute("alg");
                 $xmlWriter->text($hashType);
                 $xmlWriter->endAttribute();
-                
+
                 $xmlWriter->text($hashValue);
                 $xmlWriter->endElement(); // hash
             }
@@ -131,7 +131,7 @@ class BomXmlWriter
     }
 
     /**
-     * @param XMLWriter $writer The XMLWriter instance to use
+     * @param XMLWriter $xmlWriter The XMLWriter instance to use
      * @param string $elementName Name of the element
      * @param string $elementText Text of the element
      */

--- a/src/ComposerCommandProvider.php
+++ b/src/ComposerCommandProvider.php
@@ -21,8 +21,8 @@
 
 namespace CycloneDX;
 
-use Composer\Plugin\Capability\CommandProvider;
 use Composer\Command\BaseCommand;
+use Composer\Plugin\Capability\CommandProvider;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -34,32 +34,32 @@ class ComposerCommandProvider implements CommandProvider
 {
     public function getCommands()
     {
-        return array(new MakeBomCommand);
-    }   
+        return [new MakeBomCommand()];
+    }
 }
 
 /**
  * The Plugin's makeBom command.
- * 
+ *
  * @author nscuro
  */
 class MakeBomCommand extends BaseCommand
 {
-    const OPTION_OUTPUT_FILE = "output-file";
-    const OPTION_EXCLUDE_DEV = "exclude-dev";
-    const OPTION_EXCLUDE_PLUGINS = "exclude-plugins";
-    const OPTION_JSON = "json";
+    const OPTION_OUTPUT_FILE = 'output-file';
+    const OPTION_EXCLUDE_DEV = 'exclude-dev';
+    const OPTION_EXCLUDE_PLUGINS = 'exclude-plugins';
+    const OPTION_JSON = 'json';
 
     protected function configure()
     {
         $this
-            ->setName("make-bom")
-            ->setDescription("Generate a CycloneDX Bill of Materials");
+            ->setName('make-bom')
+            ->setDescription('Generate a CycloneDX Bill of Materials');
 
-        $this->addOption($this::OPTION_OUTPUT_FILE, null, InputOption::VALUE_REQUIRED, "Path to the output file (default is bom.xml or bom.json)");
-        $this->addOption($this::OPTION_EXCLUDE_DEV, null, InputOption::VALUE_NONE, "Exclude dev dependencies");
-        $this->addOption($this::OPTION_EXCLUDE_PLUGINS, null, InputOption::VALUE_NONE, "Exclude composer plugins");
-        $this->addOption($this::OPTION_JSON, null, InputOption::VALUE_NONE, "Produce the BOM in JSON format (preview support)");
+        $this->addOption($this::OPTION_OUTPUT_FILE, null, InputOption::VALUE_REQUIRED, 'Path to the output file (default is bom.xml or bom.json)');
+        $this->addOption($this::OPTION_EXCLUDE_DEV, null, InputOption::VALUE_NONE, 'Exclude dev dependencies');
+        $this->addOption($this::OPTION_EXCLUDE_PLUGINS, null, InputOption::VALUE_NONE, 'Exclude composer plugins');
+        $this->addOption($this::OPTION_JSON, null, InputOption::VALUE_NONE, 'Produce the BOM in JSON format (preview support)');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -67,31 +67,32 @@ class MakeBomCommand extends BaseCommand
         $locker = $this->getComposer()->getLocker();
 
         if (!$locker->isLocked()) {
-            $output->writeln("<error>Lockfile does not exist</error>");
+            $output->writeln('<error>Lockfile does not exist</error>');
+
             return;
         }
-        
-        $output->writeln("<info>Generating BOM from lockfile</info>");
+
+        $output->writeln('<info>Generating BOM from lockfile</info>');
         $bomGenerator = new BomGenerator($output);
         $bom = $bomGenerator->generateBom(
-            $locker->getLockData(), 
-            $input->getOption($this::OPTION_EXCLUDE_DEV) !== false, 
-            $input->getOption($this::OPTION_EXCLUDE_PLUGINS) !== false
+            $locker->getLockData(),
+            false !== $input->getOption($this::OPTION_EXCLUDE_DEV),
+            false !== $input->getOption($this::OPTION_EXCLUDE_PLUGINS)
         );
 
-        $output->writeln("<info>Writing BOM</info>");
+        $output->writeln('<info>Writing BOM</info>');
 
-        if ($input->getOption($this::OPTION_JSON) !== false) {
+        if (false !== $input->getOption($this::OPTION_JSON)) {
             $bomWriter = new BomJsonWriter($output);
-            $outputFile = $input->getOption($this::OPTION_OUTPUT_FILE) ? $input->getOption($this::OPTION_OUTPUT_FILE) : "bom.json";
+            $outputFile = $input->getOption($this::OPTION_OUTPUT_FILE) ? $input->getOption($this::OPTION_OUTPUT_FILE) : 'bom.json';
         } else {
             $bomWriter = new BomXmlWriter($output);
-            $outputFile = $input->getOption($this::OPTION_OUTPUT_FILE) ? $input->getOption($this::OPTION_OUTPUT_FILE) : "bom.xml";
+            $outputFile = $input->getOption($this::OPTION_OUTPUT_FILE) ? $input->getOption($this::OPTION_OUTPUT_FILE) : 'bom.xml';
         }
 
         $bomContents = $bomWriter->writeBom($bom);
 
-        $output->writeln("<info>Writing output to " . $outputFile . "</info>");
+        $output->writeln('<info>Writing output to '.$outputFile.'</info>');
         \file_put_contents($outputFile, $bomContents);
     }
 }

--- a/src/ComposerPlugin.php
+++ b/src/ComposerPlugin.php
@@ -31,7 +31,7 @@ use Composer\Plugin\PluginInterface;
  */
 class ComposerPlugin implements PluginInterface, Capable
 {
-    public function activate(Composer $composer, IOInterface $io) 
+    public function activate(Composer $composer, IOInterface $io)
     {
         // Nothing to do
     }
@@ -48,8 +48,8 @@ class ComposerPlugin implements PluginInterface, Capable
 
     public function getCapabilities()
     {
-        return array(
+        return [
             'Composer\Plugin\Capability\CommandProvider' => 'CycloneDX\ComposerCommandProvider',
-        );
+        ];
     }
 }

--- a/src/Model/Bom.php
+++ b/src/Model/Bom.php
@@ -31,7 +31,7 @@ class Bom
      */
     private $components;
 
-    function __construct(array $components)
+    public function __construct(array $components)
     {
         $this->components = $components;
     }
@@ -40,5 +40,4 @@ class Bom
     {
         return $this->components;
     }
-
 }

--- a/src/Model/Bom.php
+++ b/src/Model/Bom.php
@@ -36,7 +36,7 @@ class Bom
         $this->components = $components;
     }
 
-    public function getComponents() 
+    public function getComponents()
     {
         return $this->components;
     }

--- a/src/Model/Component.php
+++ b/src/Model/Component.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 /*
  * This file is part of the CycloneDX PHP Composer Plugin.
@@ -66,132 +66,150 @@ class Component implements \JsonSerializable
      */
     private $hashes;
 
-    public function getName() {
+    public function getName()
+    {
         return $this->name;
     }
 
     /**
      * @param string $name
      */
-    public function setName($name) {
+    public function setName($name)
+    {
         $this->name = $name;
     }
 
     /**
      * @return string
      */
-    public function getGroup() {
+    public function getGroup()
+    {
         return $this->group;
     }
 
     /**
      * @param string $group
      */
-    public function setGroup($group) {
+    public function setGroup($group)
+    {
         $this->group = $group;
     }
 
     /**
      * @return string
      */
-    public function getType() {
+    public function getType()
+    {
         return $this->type;
     }
 
     /**
      * @param string $type
      */
-    public function setType($type) {
+    public function setType($type)
+    {
         $this->type = $type;
     }
 
     /**
      * @return string
      */
-    public function getVersion() {
+    public function getVersion()
+    {
         return $this->version;
     }
 
     /**
      * @param string $version
      */
-    public function setVersion($version) {
+    public function setVersion($version)
+    {
         $this->version = $version;
     }
 
     /**
      * @return string
      */
-    public function getDescription() {
+    public function getDescription()
+    {
         return $this->description;
     }
 
     /**
      * @param string $description
      */
-    public function setDescription($description) {
+    public function setDescription($description)
+    {
         $this->description = $description;
     }
 
     /**
      * @return array
      */
-    public function getLicenses() {
+    public function getLicenses()
+    {
         return $this->licenses;
     }
 
     /**
      * @param array $licenses
      */
-    public function setLicenses($licenses) {
+    public function setLicenses($licenses)
+    {
         $this->licenses = $licenses;
     }
 
     /**
      * @return string
      */
-    public function getPackageUrl() {
+    public function getPackageUrl()
+    {
         return $this->packageUrl;
     }
 
     /**
      * @param string $packageUrl
      */
-    public function setPackageUrl($packageUrl) {
+    public function setPackageUrl($packageUrl)
+    {
         $this->packageUrl = $packageUrl;
     }
 
     /**
      * @return array
      */
-    public function getHashes() {
+    public function getHashes()
+    {
         return $this->hashes;
     }
 
     /**
      * @param array $hashes
      */
-    public function setHashes($hashes) {
+    public function setHashes($hashes)
+    {
         $this->hashes = $hashes;
     }
 
-    public function jsonSerialize() {
+    public function jsonSerialize()
+    {
         $licenses = [];
         foreach ($this->licenses as $license) {
             $licenses[] = [
-                "license" => [
-                    "id" => $license,
+                'license' => [
+                    'id' => $license,
                 ],
             ];
         }
+
         return [
-            "name" => $this->name,
-            "group" => $this->group,
-            "type" => $this->type,
-            "version" => $this->version,
-            "description" => $this->description,
-            "licenses" => $licenses,
-            "purl" => $this->packageUrl,
+            'name' => $this->name,
+            'group' => $this->group,
+            'type' => $this->type,
+            'version' => $this->version,
+            'description' => $this->description,
+            'licenses' => $licenses,
+            'purl' => $this->packageUrl,
         ];
     }
 }

--- a/src/Spdx/XmlLicense.php
+++ b/src/Spdx/XmlLicense.php
@@ -30,7 +30,7 @@ use RuntimeException;
  */
 class XmlLicense
 {
-    const LICENSES_FILE = 'xml-spdx-licenses.json';
+    public const LICENSES_FILE = 'xml-spdx-licenses.json';
 
     /**
      * @var string[]

--- a/src/Spdx/XmlLicense.php
+++ b/src/Spdx/XmlLicense.php
@@ -42,13 +42,12 @@ class XmlLicense
         $this->loadLicenses();
     }
 
-
     /**
      * @return string
      */
     public static function getResourcesFile()
     {
-        return __DIR__ . '/../../res/' . self::LICENSES_FILE;
+        return __DIR__.'/../../res/'.self::LICENSES_FILE;
     }
 
     /**
@@ -63,10 +62,10 @@ class XmlLicense
         $file = self::getResourcesFile();
         $json = file_get_contents($file);
         if (false === $json) {
-            throw new RuntimeException('Missing license file in ' . $file);
+            throw new RuntimeException('Missing license file in '.$file);
         }
 
-        $this->licenses = array();
+        $this->licenses = [];
 
         $options = 0;
 
@@ -81,6 +80,7 @@ class XmlLicense
 
     /**
      * @param string
+     *
      * @return bool
      */
     public function validate($identifier)
@@ -90,15 +90,15 @@ class XmlLicense
 
     /**
      * @param string
-     * @return null|string
+     *
+     * @return string|null
      */
     public function getLicense($identifier)
     {
         $key = strtolower($identifier);
+
         return array_key_exists($key, $this->licenses)
             ? $this->licenses[$key]
             : null;
     }
-
-
 }

--- a/tests/BomGeneratorTest.php
+++ b/tests/BomGeneratorTest.php
@@ -1,6 +1,23 @@
 <?php
 
-/** @noinspection PhpUnhandledExceptionInspection */
+/*
+ * This file is part of the CycloneDX PHP Composer Plugin.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
 
 use CycloneDX\BomGenerator;
 use PHPUnit\Framework\TestCase;
@@ -31,74 +48,74 @@ class BomGeneratorTest extends TestCase
 
     public function testGenerateBom(): void
     {
-        $packages = array(
-            array(
-                "name" => "vendorName/packageName",
-                "version" => "1.0",
-                "type" => "library"
-            )
-        );
-        $packagesDev = array(
-            array(
-                "name" => "vendorNameDev/packageNameDev",
-                "version" => "2.0",
-                "type" => "library"
-            )
-        );
-        $lockData = array(
-            "packages" => $packages,
-            "packages-dev" => $packagesDev
-        );
+        $packages = [
+            [
+                'name' => 'vendorName/packageName',
+                'version' => '1.0',
+                'type' => 'library',
+            ],
+        ];
+        $packagesDev = [
+            [
+                'name' => 'vendorNameDev/packageNameDev',
+                'version' => '2.0',
+                'type' => 'library',
+            ],
+        ];
+        $lockData = [
+            'packages' => $packages,
+            'packages-dev' => $packagesDev,
+        ];
 
         $bom = $this->bomGenerator->generateBom($lockData, false, false);
         self::assertCount(2, $bom->getComponents());
 
-        $componentNames = array_map(static function($component) { return $component->getName(); }, $bom->getComponents());
-        self::assertContains("packageName", $componentNames);
-        self::assertContains("packageNameDev", $componentNames);
+        $componentNames = array_map(static function ($component) { return $component->getName(); }, $bom->getComponents());
+        self::assertContains('packageName', $componentNames);
+        self::assertContains('packageNameDev', $componentNames);
     }
 
     public function testGenerateBomExcludeDev(): void
     {
-        $packages = array(
-            array(
-                "name" => "vendorName/packageName",
-                "version" => "1.0",
-                "type" => "library"
-            )
-        );
-        $packagesDev = array(
-            array(
-                "name" => "vendorNameDev/packageNameDev",
-                "version" => "2.0",
-                "type" => "library"
-            )
-        );
-        $lockData = array(
-            "packages" => $packages,
-            "packages-dev" => $packagesDev
-        );
+        $packages = [
+            [
+                'name' => 'vendorName/packageName',
+                'version' => '1.0',
+                'type' => 'library',
+            ],
+        ];
+        $packagesDev = [
+            [
+                'name' => 'vendorNameDev/packageNameDev',
+                'version' => '2.0',
+                'type' => 'library',
+            ],
+        ];
+        $lockData = [
+            'packages' => $packages,
+            'packages-dev' => $packagesDev,
+        ];
 
         $bom = $this->bomGenerator->generateBom($lockData, true, false);
         self::assertCount(1, $bom->getComponents());
 
-        $componentNames = array_map(static function($component) { return $component->getName(); }, $bom->getComponents());
-        self::assertContains("packageName", $componentNames);
+        $componentNames = array_map(static function ($component) { return $component->getName(); }, $bom->getComponents());
+        self::assertContains('packageName', $componentNames);
     }
 
     public function testGenerateBomExcludePlugins(): void
     {
-        $packages = array(
-            array(
-                "name" => "vendorName/packageName",
-                "version" => "1.0",
-                "type" => "composer-plugin"
-            )
-        );
-        $lockData = array(
-            "packages" => $packages,
-            "packages-dev" => array()
-        );
+        $packages = [
+            [
+                'name' => 'vendorName/packageName',
+                'version' => '1.0',
+                'type' => 'composer-plugin',
+            ],
+        ];
+        $lockData = [
+            'packages' => $packages,
+            'packages-dev' => [],
+        ];
 
         $bom = $this->bomGenerator->generateBom($lockData, false, true);
         self::assertCount(0, $bom->getComponents());
@@ -106,96 +123,96 @@ class BomGeneratorTest extends TestCase
 
     public function testBuildComponent(): void
     {
-        $packageData = array(
-            "name" => "vendorName/packageName",
-            "version" => "v6.6.6",
-            "description" => "packageDescription",
-            "license" => "MIT",
-            "dist" => array(
-                "shasum" => "7e240de74fb1ed08fa08d38063f6a6a91462a815"
-            )
-        );
+        $packageData = [
+            'name' => 'vendorName/packageName',
+            'version' => 'v6.6.6',
+            'description' => 'packageDescription',
+            'license' => 'MIT',
+            'dist' => [
+                'shasum' => '7e240de74fb1ed08fa08d38063f6a6a91462a815',
+            ],
+        ];
 
         $component = $this->bomGenerator->buildComponent($packageData);
 
-        self::assertSame("packageName", $component->getName());
-        self::assertSame("vendorName", $component->getGroup());
-        self::assertSame("6.6.6", $component->getVersion());
-        self::assertSame("packageDescription", $component->getDescription());
-        self::assertSame("library", $component->getType());
+        self::assertSame('packageName', $component->getName());
+        self::assertSame('vendorName', $component->getGroup());
+        self::assertSame('6.6.6', $component->getVersion());
+        self::assertSame('packageDescription', $component->getDescription());
+        self::assertSame('library', $component->getType());
         self::assertCount(1, $component->getLicenses());
-        self::assertContains("MIT", $component->getLicenses());
-        self::assertArrayHasKey("SHA-1", $component->getHashes());
-        self::assertSame("7e240de74fb1ed08fa08d38063f6a6a91462a815", $component->getHashes()["SHA-1"]);
-        self::assertSame("pkg:composer/vendorName/packageName@6.6.6", $component->getPackageUrl());
+        self::assertContains('MIT', $component->getLicenses());
+        self::assertArrayHasKey('SHA-1', $component->getHashes());
+        self::assertSame('7e240de74fb1ed08fa08d38063f6a6a91462a815', $component->getHashes()['SHA-1']);
+        self::assertSame('pkg:composer/vendorName/packageName@6.6.6', $component->getPackageUrl());
     }
 
     public function testBuildComponentWithoutVendor(): void
     {
-        $packageData = array(
-            "name" => "packageName",
-            "version" => "1.0",
-        );
+        $packageData = [
+            'name' => 'packageName',
+            'version' => '1.0',
+        ];
 
         $component = $this->bomGenerator->buildComponent($packageData);
 
-        self::assertSame("packageName", $component->getName());
+        self::assertSame('packageName', $component->getName());
         self::assertNull($component->getGroup());
-        self::assertSame("1.0", $component->getVersion());
+        self::assertSame('1.0', $component->getVersion());
         self::assertNull($component->getDescription());
         self::assertEmpty($component->getLicenses());
         self::assertEmpty($component->getHashes());
-        self::assertSame("pkg:composer/packageName@1.0", $component->getPackageUrl());
+        self::assertSame('pkg:composer/packageName@1.0', $component->getPackageUrl());
     }
 
     public function testBuildComponentWithoutName(): void
     {
-        $packageData = array("version" => "1.0");
+        $packageData = ['version' => '1.0'];
 
         $this->expectException(UnexpectedValueException::class);
-        $this->expectExceptionMessage("Encountered package without name: {\"version\":\"1.0\"}");
+        $this->expectExceptionMessage('Encountered package without name: {"version":"1.0"}');
 
         $this->bomGenerator->buildComponent($packageData);
     }
 
     public function testBuildComponentWithoutVersion(): void
     {
-        $packageData = array("name" => "vendorName/packageName");
+        $packageData = ['name' => 'vendorName/packageName'];
 
         $this->expectException(UnexpectedValueException::class);
-        $this->expectExceptionMessage("Encountered package without version: vendorName/packageName");
+        $this->expectExceptionMessage('Encountered package without version: vendorName/packageName');
 
         $this->bomGenerator->buildComponent($packageData);
     }
 
     public function testReadLicensesWithLicenseString(): void
     {
-        $licenses = $this->bomGenerator->readLicenses(array("license" => "MIT"));
+        $licenses = $this->bomGenerator->readLicenses(['license' => 'MIT']);
         self::assertCount(1, $licenses);
-        self::assertContains("MIT", $licenses);
+        self::assertContains('MIT', $licenses);
     }
 
     public function testReadLicensesWithDisjunctiveLicenseString(): void
     {
-        $licenses = $this->bomGenerator->readLicenses(array("license" => "(MIT or Apache-2.0)"));
+        $licenses = $this->bomGenerator->readLicenses(['license' => '(MIT or Apache-2.0)']);
         self::assertCount(2, $licenses);
-        self::assertContains("MIT", $licenses);
-        self::assertContains("Apache-2.0", $licenses);
+        self::assertContains('MIT', $licenses);
+        self::assertContains('Apache-2.0', $licenses);
     }
 
     public function testReadLicensesWithConjunctiveLicenseString(): void
     {
-        $licenses = $this->bomGenerator->readLicenses(array("license" => "(MIT and Apache-2.0)"));
+        $licenses = $this->bomGenerator->readLicenses(['license' => '(MIT and Apache-2.0)']);
         self::assertCount(2, $licenses);
-        self::assertContains("MIT", $licenses);
-        self::assertContains("Apache-2.0", $licenses);
+        self::assertContains('MIT', $licenses);
+        self::assertContains('Apache-2.0', $licenses);
     }
 
     public function testReadLicensesWithDisjunctiveLicenseArray(): void
     {
-        $licenses = $this->bomGenerator->readLicenses(array("license" => array("MIT", "Apache-2.0")));
+        $licenses = $this->bomGenerator->readLicenses(['license' => ['MIT', 'Apache-2.0']]);
         self::assertCount(2, $licenses);
-        self::assertContains("MIT", $licenses);
-        self::assertContains("Apache-2.0", $licenses);
+        self::assertContains('MIT', $licenses);
+        self::assertContains('Apache-2.0', $licenses);
     }
 }

--- a/tests/BomJsonWriterTest.php
+++ b/tests/BomJsonWriterTest.php
@@ -1,13 +1,30 @@
 <?php
 
-/** @noinspection PhpUnhandledExceptionInspection */
+/*
+ * This file is part of the CycloneDX PHP Composer Plugin.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
 
 use CycloneDX\BomJsonWriter;
 use CycloneDX\Model\Bom;
 use CycloneDX\Model\Component;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Console\Output\OutputInterface;
 use Swaggest\JsonSchema\Schema;
+use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * @coversNothing
@@ -24,7 +41,7 @@ class BomJsonWriterTest extends TestCase
      */
     private $bomJsonWriter;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -34,19 +51,18 @@ class BomJsonWriterTest extends TestCase
 
     public function testBomJsonWriter(): void
     {
-        $schemaJson = file_get_contents(__DIR__ . "/schema/bom-1.2.schema-SNAPSHOT.json");
+        $schemaJson = file_get_contents(__DIR__.'/schema/bom-1.2.schema-SNAPSHOT.json');
         $schema = Schema::import(json_decode($schemaJson, false));
-        $component = new Component;
-        $component->setGroup("componentGroup");
-        $component->setName("componentName");
-        $component->setDescription("componentDescription");
-        $component->setVersion("1.0");
-        $component->setType("library");
-        $component->setLicenses(array("MIT", "Apache-2.0"));
-        $component->setHashes(array("SHA-1" => "7e240de74fb1ed08fa08d38063f6a6a91462a815"));
-        $component->setPackageUrl("purl://packageurl");
-        $bom = new Bom(array($component));
-
+        $component = new Component();
+        $component->setGroup('componentGroup');
+        $component->setName('componentName');
+        $component->setDescription('componentDescription');
+        $component->setVersion('1.0');
+        $component->setType('library');
+        $component->setLicenses(['MIT', 'Apache-2.0']);
+        $component->setHashes(['SHA-1' => '7e240de74fb1ed08fa08d38063f6a6a91462a815']);
+        $component->setPackageUrl('purl://packageurl');
+        $bom = new Bom([$component]);
 
         $bomJson = $this->bomJsonWriter->writeBom($bom);
 
@@ -55,5 +71,4 @@ class BomJsonWriterTest extends TestCase
         // this stops PHPUnit from flagging this as a risky test
         $this->expectNotToPerformAssertions();
     }
-
 }

--- a/tests/BomXmlWriterTest.php
+++ b/tests/BomXmlWriterTest.php
@@ -1,7 +1,23 @@
 <?php
 
-/** @noinspection PhpUnhandledExceptionInspection */
-
+/*
+ * This file is part of the CycloneDX PHP Composer Plugin.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
 
 use CycloneDX\BomXmlWriter;
 use CycloneDX\Model\Bom;
@@ -24,7 +40,7 @@ class BomXmlWriterTest extends TestCase
      */
     private $bomXmlWriter;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -34,76 +50,75 @@ class BomXmlWriterTest extends TestCase
 
     public function testBomXmlWriter(): void
     {
-        $component = new Component;
-        $component->setGroup("componentGroup");
-        $component->setName("componentName");
-        $component->setDescription("componentDescription");
-        $component->setVersion("1.0");
-        $component->setType("library");
-        $component->setLicenses(array("MIT", "Apache-2.0"));
-        $component->setHashes(array("SHA-1" => "7e240de74fb1ed08fa08d38063f6a6a91462a815"));
-        $bom = new Bom(array($component));
+        $component = new Component();
+        $component->setGroup('componentGroup');
+        $component->setName('componentName');
+        $component->setDescription('componentDescription');
+        $component->setVersion('1.0');
+        $component->setType('library');
+        $component->setLicenses(['MIT', 'Apache-2.0']);
+        $component->setHashes(['SHA-1' => '7e240de74fb1ed08fa08d38063f6a6a91462a815']);
+        $bom = new Bom([$component]);
 
         $bomXml = $this->bomXmlWriter->writeBom($bom);
 
-        $domDocument = new DOMDocument("1.0", "UTF-8");
+        $domDocument = new DOMDocument('1.0', 'UTF-8');
         $domDocument->loadXML($bomXml);
-        self::assertTrue($domDocument->schemaValidate(__DIR__ . "/schema/bom-1.1.xsd"));
+        self::assertTrue($domDocument->schemaValidate(__DIR__.'/schema/bom-1.1.xsd'));
     }
 
     /**
      * license is unknown to https://cyclonedx.org/schema/spdx
-     * but BOM still valid output
+     * but BOM still valid output.
      */
     public function testUnknownSpdxLicense(): void
     {
-        $component = new Component;
-        $component->setGroup("componentGroup");
-        $component->setName("componentName");
-        $component->setDescription("componentDescription");
-        $component->setVersion("1.0");
-        $component->setType("library");
-        $component->setLicenses(array("proprietary"));
-        $component->setHashes(array("SHA-1" => "7e240de74fb1ed08fa08d38063f6a6a91462a815"));
-        $bom = new Bom(array($component));
+        $component = new Component();
+        $component->setGroup('componentGroup');
+        $component->setName('componentName');
+        $component->setDescription('componentDescription');
+        $component->setVersion('1.0');
+        $component->setType('library');
+        $component->setLicenses(['proprietary']);
+        $component->setHashes(['SHA-1' => '7e240de74fb1ed08fa08d38063f6a6a91462a815']);
+        $bom = new Bom([$component]);
 
         $bomXml = $this->bomXmlWriter->writeBom($bom);
 
-        $domDocument = new DOMDocument("1.0", "UTF-8");
+        $domDocument = new DOMDocument('1.0', 'UTF-8');
         $domDocument->loadXML($bomXml);
-        self::assertTrue($domDocument->schemaValidate(__DIR__ . "/schema/bom-1.1.xsd"));
+        self::assertTrue($domDocument->schemaValidate(__DIR__.'/schema/bom-1.1.xsd'));
     }
 
     /**
      * license is unknown to https://cyclonedx.org/schema/spdx
-     * but BOM still valid output
+     * but BOM still valid output.
      */
     public function testCaseMismatchSpdxLicense(): void
     {
-        $mismatch = array("mit", "aPACHE-2.0");
-        $expected = array("MIT", "Apache-2.0");
+        $mismatch = ['mit', 'aPACHE-2.0'];
+        $expected = ['MIT', 'Apache-2.0'];
 
-        $component = new Component;
-        $component->setGroup("componentGroup");
-        $component->setName("componentName");
-        $component->setDescription("componentDescription");
-        $component->setVersion("1.0");
-        $component->setType("library");
+        $component = new Component();
+        $component->setGroup('componentGroup');
+        $component->setName('componentName');
+        $component->setDescription('componentDescription');
+        $component->setVersion('1.0');
+        $component->setType('library');
         $component->setLicenses($mismatch);
-        $component->setHashes(array("SHA-1" => "7e240de74fb1ed08fa08d38063f6a6a91462a815"));
-        $bom = new Bom(array($component));
+        $component->setHashes(['SHA-1' => '7e240de74fb1ed08fa08d38063f6a6a91462a815']);
+        $bom = new Bom([$component]);
 
         $bomXml = $this->bomXmlWriter->writeBom($bom);
 
-        $domDocument = new DOMDocument("1.0", "UTF-8");
+        $domDocument = new DOMDocument('1.0', 'UTF-8');
         $domDocument->loadXML($bomXml);
-        self::assertTrue($domDocument->schemaValidate(__DIR__ . "/schema/bom-1.1.xsd"));
+        self::assertTrue($domDocument->schemaValidate(__DIR__.'/schema/bom-1.1.xsd'));
 
-        $domDocumentLicenses = array();
+        $domDocumentLicenses = [];
         foreach ($domDocument->getElementsByTagName('license') as $domDocumentLicense) {
             $domDocumentLicenses[] = $domDocumentLicense->getElementsByTagName('id')[0]->nodeValue;
         }
         self::assertSame($expected, $domDocumentLicenses);
     }
-
 }

--- a/tests/ShippedXmlSpdxLicensesTest.php
+++ b/tests/ShippedXmlSpdxLicensesTest.php
@@ -1,10 +1,26 @@
 <?php
 
-/** @noinspection PhpUnhandledExceptionInspection */
+/*
+ * This file is part of the CycloneDX PHP Composer Plugin.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
 
 use CycloneDX\Spdx\XmlLicense;
 use PHPUnit\Framework\TestCase;
-
 
 /**
  * @coversNothing
@@ -27,7 +43,6 @@ class ShippedXmlSpdxLicensesTest extends TestCase
     public function test(): void
     {
         self::assertFileExists($this->file);
-
 
         $json = file_get_contents($this->file);
         self::assertJson($json);

--- a/tools/php-cs-fixer/.gitignore
+++ b/tools/php-cs-fixer/.gitignore
@@ -1,0 +1,3 @@
+*
+!/.gitignore
+!/composer.json

--- a/tools/php-cs-fixer/composer.json
+++ b/tools/php-cs-fixer/composer.json
@@ -1,0 +1,16 @@
+{
+    "name": "tools/php-cs-fixer",
+    "description": "php-cs-fixer",
+    "type": "metapackage",
+    "config": {
+        "preferred-install": "dist",
+        "sort-packages": true
+    },
+    "prefer-stable": true,
+    "require": {
+        "friendsofphp/php-cs-fixer": "2.18.4"
+    },
+    "require-dev": {
+        "roave/security-advisories": "dev-latest"
+    }
+}


### PR DESCRIPTION
added tool: php-cs-fixer

added to basic test suite
added basic config
did some safe fixes to the code - accessors, phpdoc-annotations, ...
applied basic config to all code in `src/` and `tests/`
updated psalm baseline accordingly

is part of #23