### PR TITLE
Issue #14

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,24 @@
 
 ## unreleased
 
+* Changed
+  * Core library
+    * SerializersGroups will skipp unsupported elements silently, instead of forwarding caught exceptions.  
+      This results in an overall smoother SBoM generation process, just as intended.
+* Added
+  * CLI via `composer make-bom`
+    * Will try to populate metadata of the SBoM.
+  * Core library
+    * Added models for spec elements: `metadata`, `tools`, `tool`
+    * Added ability to serialize `metadata` to XML
+    * Added ability to serialize `metadata` to JSON
+* Fixed
+  * CLI via `composer make-bom`
+    * composer packages of type `project` or `composer-plugin` 
+      result as CycloneDX component of type `application`, was `library`.
+* Misc
+  * Split some tests to more fine-grained scenarios.
+
 ## 3.2.0
 
 * Changed

--- a/demo/laravel-7.12.0/README.md
+++ b/demo/laravel-7.12.0/README.md
@@ -49,3 +49,17 @@ Run one of these from the demo directory:
   composer -dproject make-bom --exclude-dev --spec-version=1.2 --output-format=JSON --output-file="$PWD/results/bom.1.2.json"
   composer -dproject make-bom --exclude-dev --spec-version=1.3 --output-format=JSON --output-file="$PWD/results/bom.1.3.json"
   ```
+
+## dev-maintenance
+
+Lock-file should stay in a certain state, after updating dependencies.
+
+Upgrade the `composer.lock` tile to the latest changes to the plugin via:
+1. run `composer -dproject update 'cyclonedx/cyclonedx-php-composer'`
+2. revert in the `composer.lock` some setup 
+   * for package `cyclonedx/cyclonedx-php-composer`:
+     * set `version` to `dev-master`
+     * delete the `dist.reference`
+   * set `plugin-api-version` to `2.0.0`
+
+Then re-generate all results as shown in section above.

--- a/demo/laravel-7.12.0/project/composer.json
+++ b/demo/laravel-7.12.0/project/composer.json
@@ -1,16 +1,21 @@
 {
     "name": "cyclonedx/cyclonedx-php-composer-demo",
-    "description": "demo of cyclonedx/cyclonedx-php-composer with a pinned version of laravel/framework",
     "type": "project",
+    "description": "demo of cyclonedx/cyclonedx-php-composer with a pinned version of laravel/framework",
+    "version": "dev-master",
+    "require": {
+        "laravel/laravel": "7.12.0"
+    },
+    "require-dev": {
+        "cyclonedx/cyclonedx-php-composer": "@dev"
+    },
     "config": {
-        "sort-packages": true,
-        "preferred-install": "dist",
         "platform": {
             "php": "7.3"
-        }
+        },
+        "preferred-install": "dist",
+        "sort-packages": true
     },
-    "minimum-stability": "stable",
-    "prefer-stable": true,
     "repositories": [
         {
             "type": "path",
@@ -18,10 +23,6 @@
             "symlink": true
         }
     ],
-    "require": {
-        "laravel/laravel": "7.12.0"
-    },
-    "require-dev": {
-        "cyclonedx/cyclonedx-php-composer": "@dev"
-    }
+    "minimum-stability": "stable",
+    "prefer-stable": true
 }

--- a/demo/laravel-7.12.0/project/composer.lock
+++ b/demo/laravel-7.12.0/project/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a7d3a418be2bfd9bdb787ec5c93985fc",
+    "content-hash": "86b7d5a89aa0649f53ff01e733715352",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -4693,7 +4693,7 @@
             "require-dev": {
                 "composer/composer": "^2.0.13",
                 "ext-simplexml": "*",
-                "phpunit/phpunit": "9.5.6",
+                "phpunit/phpunit": "9.5.7",
                 "roave/security-advisories": "dev-latest"
             },
             "type": "composer-plugin",
@@ -4778,6 +4778,15 @@
             ],
             "description": "Creates CycloneDX Software Bill-of-Materials (SBOM) from PHP Composer projects",
             "homepage": "https://github.com/CycloneDX/cyclonedx-php-composer/",
+            "keywords": [
+                "BOM",
+                "CycloneDX",
+                "PURL",
+                "SBOM",
+                "bill-of-materials",
+                "package-url",
+                "software-bill-of-materials"
+            ],
             "support": {
                 "issues": "https://github.com/CycloneDX/cyclonedx-php-composer/issues"
             },

--- a/demo/laravel-7.12.0/results/bom.1.1.xml
+++ b/demo/laravel-7.12.0/results/bom.1.1.xml
@@ -145,7 +145,7 @@
       </licenses>
       <purl><![CDATA[pkg:composer/laravel/framework@7.30.4]]></purl>
     </component>
-    <component type="library">
+    <component type="application">
       <group><![CDATA[laravel]]></group>
       <name><![CDATA[laravel]]></name>
       <version><![CDATA[7.12.0]]></version>

--- a/demo/laravel-7.12.0/results/bom.1.2.json
+++ b/demo/laravel-7.12.0/results/bom.1.2.json
@@ -2,6 +2,23 @@
     "bomFormat": "CycloneDX",
     "specVersion": "1.2",
     "version": 1,
+    "metadata": {
+        "tools": [
+            {
+                "vendor": "cyclonedx",
+                "name": "cyclonedx-php-composer",
+                "version": "dev-master"
+            }
+        ],
+        "component": {
+            "type": "application",
+            "name": "cyclonedx-php-composer-demo",
+            "version": "dev-master",
+            "group": "cyclonedx",
+            "description": "demo of cyclonedx\/cyclonedx-php-composer with a pinned version of laravel\/framework",
+            "purl": "pkg:composer\/cyclonedx\/cyclonedx-php-composer-demo@dev-master"
+        }
+    },
     "components": [
         {
             "type": "library",
@@ -184,7 +201,7 @@
             "purl": "pkg:composer\/laravel\/framework@7.30.4"
         },
         {
-            "type": "library",
+            "type": "application",
             "name": "laravel",
             "version": "7.12.0",
             "group": "laravel",

--- a/demo/laravel-7.12.0/results/bom.1.2.xml
+++ b/demo/laravel-7.12.0/results/bom.1.2.xml
@@ -1,5 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bom xmlns="http://cyclonedx.org/schema/bom/1.2" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor><![CDATA[cyclonedx]]></vendor>
+        <name><![CDATA[cyclonedx-php-composer]]></name>
+        <version><![CDATA[dev-master]]></version>
+      </tool>
+    </tools>
+    <component type="application">
+      <group><![CDATA[cyclonedx]]></group>
+      <name><![CDATA[cyclonedx-php-composer-demo]]></name>
+      <version><![CDATA[dev-master]]></version>
+      <description><![CDATA[demo of cyclonedx/cyclonedx-php-composer with a pinned version of laravel/framework]]></description>
+      <purl><![CDATA[pkg:composer/cyclonedx/cyclonedx-php-composer-demo@dev-master]]></purl>
+    </component>
+  </metadata>
   <components>
     <component type="library">
       <group><![CDATA[asm89]]></group>
@@ -145,7 +161,7 @@
       </licenses>
       <purl><![CDATA[pkg:composer/laravel/framework@7.30.4]]></purl>
     </component>
-    <component type="library">
+    <component type="application">
       <group><![CDATA[laravel]]></group>
       <name><![CDATA[laravel]]></name>
       <version><![CDATA[7.12.0]]></version>

--- a/demo/laravel-7.12.0/results/bom.1.3.json
+++ b/demo/laravel-7.12.0/results/bom.1.3.json
@@ -2,6 +2,23 @@
     "bomFormat": "CycloneDX",
     "specVersion": "1.3",
     "version": 1,
+    "metadata": {
+        "tools": [
+            {
+                "vendor": "cyclonedx",
+                "name": "cyclonedx-php-composer",
+                "version": "dev-master"
+            }
+        ],
+        "component": {
+            "type": "application",
+            "name": "cyclonedx-php-composer-demo",
+            "version": "dev-master",
+            "group": "cyclonedx",
+            "description": "demo of cyclonedx\/cyclonedx-php-composer with a pinned version of laravel\/framework",
+            "purl": "pkg:composer\/cyclonedx\/cyclonedx-php-composer-demo@dev-master"
+        }
+    },
     "components": [
         {
             "type": "library",
@@ -184,7 +201,7 @@
             "purl": "pkg:composer\/laravel\/framework@7.30.4"
         },
         {
-            "type": "library",
+            "type": "application",
             "name": "laravel",
             "version": "7.12.0",
             "group": "laravel",

--- a/demo/laravel-7.12.0/results/bom.1.3.xml
+++ b/demo/laravel-7.12.0/results/bom.1.3.xml
@@ -1,5 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bom xmlns="http://cyclonedx.org/schema/bom/1.3" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor><![CDATA[cyclonedx]]></vendor>
+        <name><![CDATA[cyclonedx-php-composer]]></name>
+        <version><![CDATA[dev-master]]></version>
+      </tool>
+    </tools>
+    <component type="application">
+      <group><![CDATA[cyclonedx]]></group>
+      <name><![CDATA[cyclonedx-php-composer-demo]]></name>
+      <version><![CDATA[dev-master]]></version>
+      <description><![CDATA[demo of cyclonedx/cyclonedx-php-composer with a pinned version of laravel/framework]]></description>
+      <purl><![CDATA[pkg:composer/cyclonedx/cyclonedx-php-composer-demo@dev-master]]></purl>
+    </component>
+  </metadata>
   <components>
     <component type="library">
       <group><![CDATA[asm89]]></group>
@@ -145,7 +161,7 @@
       </licenses>
       <purl><![CDATA[pkg:composer/laravel/framework@7.30.4]]></purl>
     </component>
-    <component type="library">
+    <component type="application">
       <group><![CDATA[laravel]]></group>
       <name><![CDATA[laravel]]></name>
       <version><![CDATA[7.12.0]]></version>

--- a/demo/local/README.md
+++ b/demo/local/README.md
@@ -41,3 +41,20 @@ Run one of these from the demo directory:
   composer -dproject make-bom --exclude-dev --spec-version=1.2 --output-format=JSON --output-file="$PWD/results/bom.1.2.json"
   composer -dproject make-bom --exclude-dev --spec-version=1.3 --output-format=JSON --output-file="$PWD/results/bom.1.3.json"
   ```
+## dev-maintenance
+
+Lock-file should stay in a certain state, after updating dependencies.
+
+Upgrade the `composer.lock` tile to the latest changes to the plugin via:
+1. run `composer -dproject update 'cyclonedx/cyclonedx-php-composer'`
+2. revert in the `composer.lock` some setup
+   * for package `cyclonedx/cyclonedx-php-composer`:
+     * set `version` to `dev-master`
+     * delete the `dist.reference`
+   * for packages `cyclonedx-demo/*`
+     * delete the `dist.reference`
+   * for package `cyclonedx-demo/local-dependency-with-minimal-setup`
+     * set `version` to `dev-master`
+   * set `plugin-api-version` to `2.0.0`
+
+Then re-generate all results as shown in section above.

--- a/demo/local/project/composer.json
+++ b/demo/local/project/composer.json
@@ -1,12 +1,19 @@
 {
     "name": "cyclonedx-demo/cyclonedx-php-composer-local",
-    "description": "demo of cyclonedx/cyclonedx-php-composer with a local dependency",
     "type": "project",
-    "config": {
-        "sort-packages": true,
-        "preferred-install": "dist"
+    "description": "demo of cyclonedx/cyclonedx-php-composer with a local dependency",
+    "version": "dev-master",
+    "require": {
+        "cyclonedx-demo/local-demo-dependency": "@dev",
+        "cyclonedx-demo/local-dependency-with-minimal-setup": "@dev"
     },
-    "prefer-stable": true,
+    "require-dev": {
+        "cyclonedx/cyclonedx-php-composer": "@dev"
+    },
+    "config": {
+        "preferred-install": "dist",
+        "sort-packages": true
+    },
     "repositories": [
         {
             "type": "path",
@@ -19,11 +26,5 @@
             "symlink": true
         }
     ],
-    "require": {
-        "cyclonedx-demo/local-demo-dependency": "@dev",
-        "cyclonedx-demo/local-dependency-with-minimal-setup": "@dev"
-    },
-    "require-dev": {
-        "cyclonedx/cyclonedx-php-composer": "@dev"
-    }
+    "prefer-stable": true
 }

--- a/demo/local/project/composer.lock
+++ b/demo/local/project/composer.lock
@@ -4,15 +4,14 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e4059accfb938a17e57b4259d858c76f",
+    "content-hash": "11b0fed7055fd94d4eb0a8bcd342adc3",
     "packages": [
         {
             "name": "cyclonedx-demo/local-demo-dependency",
             "version": "1.33.7",
             "dist": {
                 "type": "path",
-                "url": "packages/local-demo-dependency",
-                "reference": "d3891c11328cd514196cc9a8d3c3e524884d5066"
+                "url": "packages/local-demo-dependency"
             },
             "type": "library",
             "description": "a package that is hosted locally and required in a local demo",
@@ -54,7 +53,7 @@
             "require-dev": {
                 "composer/composer": "^2.0.13",
                 "ext-simplexml": "*",
-                "phpunit/phpunit": "9.5.6",
+                "phpunit/phpunit": "9.5.7",
                 "roave/security-advisories": "dev-latest"
             },
             "type": "composer-plugin",
@@ -139,6 +138,15 @@
             ],
             "description": "Creates CycloneDX Software Bill-of-Materials (SBOM) from PHP Composer projects",
             "homepage": "https://github.com/CycloneDX/cyclonedx-php-composer/",
+            "keywords": [
+                "BOM",
+                "CycloneDX",
+                "PURL",
+                "SBOM",
+                "bill-of-materials",
+                "package-url",
+                "software-bill-of-materials"
+            ],
             "support": {
                 "issues": "https://github.com/CycloneDX/cyclonedx-php-composer/issues"
             },

--- a/demo/local/results/bom.1.2.json
+++ b/demo/local/results/bom.1.2.json
@@ -2,6 +2,23 @@
     "bomFormat": "CycloneDX",
     "specVersion": "1.2",
     "version": 1,
+    "metadata": {
+        "tools": [
+            {
+                "vendor": "cyclonedx",
+                "name": "cyclonedx-php-composer",
+                "version": "dev-master"
+            }
+        ],
+        "component": {
+            "type": "application",
+            "name": "cyclonedx-php-composer-local",
+            "version": "dev-master",
+            "group": "cyclonedx-demo",
+            "description": "demo of cyclonedx\/cyclonedx-php-composer with a local dependency",
+            "purl": "pkg:composer\/cyclonedx-demo\/cyclonedx-php-composer-local@dev-master"
+        }
+    },
     "components": [
         {
             "type": "library",

--- a/demo/local/results/bom.1.2.xml
+++ b/demo/local/results/bom.1.2.xml
@@ -1,5 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bom xmlns="http://cyclonedx.org/schema/bom/1.2" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor><![CDATA[cyclonedx]]></vendor>
+        <name><![CDATA[cyclonedx-php-composer]]></name>
+        <version><![CDATA[dev-master]]></version>
+      </tool>
+    </tools>
+    <component type="application">
+      <group><![CDATA[cyclonedx-demo]]></group>
+      <name><![CDATA[cyclonedx-php-composer-local]]></name>
+      <version><![CDATA[dev-master]]></version>
+      <description><![CDATA[demo of cyclonedx/cyclonedx-php-composer with a local dependency]]></description>
+      <purl><![CDATA[pkg:composer/cyclonedx-demo/cyclonedx-php-composer-local@dev-master]]></purl>
+    </component>
+  </metadata>
   <components>
     <component type="library">
       <group><![CDATA[cyclonedx-demo]]></group>

--- a/demo/local/results/bom.1.3.json
+++ b/demo/local/results/bom.1.3.json
@@ -2,6 +2,23 @@
     "bomFormat": "CycloneDX",
     "specVersion": "1.3",
     "version": 1,
+    "metadata": {
+        "tools": [
+            {
+                "vendor": "cyclonedx",
+                "name": "cyclonedx-php-composer",
+                "version": "dev-master"
+            }
+        ],
+        "component": {
+            "type": "application",
+            "name": "cyclonedx-php-composer-local",
+            "version": "dev-master",
+            "group": "cyclonedx-demo",
+            "description": "demo of cyclonedx\/cyclonedx-php-composer with a local dependency",
+            "purl": "pkg:composer\/cyclonedx-demo\/cyclonedx-php-composer-local@dev-master"
+        }
+    },
     "components": [
         {
             "type": "library",

--- a/demo/local/results/bom.1.3.xml
+++ b/demo/local/results/bom.1.3.xml
@@ -1,5 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bom xmlns="http://cyclonedx.org/schema/bom/1.3" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor><![CDATA[cyclonedx]]></vendor>
+        <name><![CDATA[cyclonedx-php-composer]]></name>
+        <version><![CDATA[dev-master]]></version>
+      </tool>
+    </tools>
+    <component type="application">
+      <group><![CDATA[cyclonedx-demo]]></group>
+      <name><![CDATA[cyclonedx-php-composer-local]]></name>
+      <version><![CDATA[dev-master]]></version>
+      <description><![CDATA[demo of cyclonedx/cyclonedx-php-composer with a local dependency]]></description>
+      <purl><![CDATA[pkg:composer/cyclonedx-demo/cyclonedx-php-composer-local@dev-master]]></purl>
+    </component>
+  </metadata>
   <components>
     <component type="library">
       <group><![CDATA[cyclonedx-demo]]></group>

--- a/demo/symfony/example-results/bom.json
+++ b/demo/symfony/example-results/bom.json
@@ -2,6 +2,23 @@
     "bomFormat": "CycloneDX",
     "specVersion": "1.3",
     "version": 1,
+    "metadata": {
+        "tools": [
+            {
+                "vendor": "cyclonedx",
+                "name": "cyclonedx-php-composer",
+                "version": "dev-issue_14"
+            }
+        ],
+        "component": {
+            "type": "application",
+            "name": "cyclonedx-php-composer-demo",
+            "version": "dev-master",
+            "group": "cyclonedx",
+            "description": "demo of cyclonedx\/cyclonedx-php-composer with symfony\/symfony",
+            "purl": "pkg:composer\/cyclonedx\/cyclonedx-php-composer-demo@dev-master"
+        }
+    },
     "components": [
         {
             "type": "library",
@@ -21,7 +38,7 @@
         {
             "type": "library",
             "name": "cache",
-            "version": "2.0.3",
+            "version": "2.1.1",
             "group": "doctrine",
             "description": "PHP Doctrine Cache library is a popular cache implementation that supports many different drivers such as redis, memcache, apc, mongodb and others.",
             "licenses": [
@@ -31,7 +48,7 @@
                     }
                 }
             ],
-            "purl": "pkg:composer\/doctrine\/cache@2.0.3"
+            "purl": "pkg:composer\/doctrine\/cache@2.1.1"
         },
         {
             "type": "library",
@@ -126,7 +143,7 @@
         {
             "type": "library",
             "name": "laminas-code",
-            "version": "4.3.0",
+            "version": "4.4.2",
             "group": "laminas",
             "description": "Extensions to the PHP Reflection API, static code scanning, and code generation",
             "licenses": [
@@ -136,37 +153,7 @@
                     }
                 }
             ],
-            "purl": "pkg:composer\/laminas\/laminas-code@4.3.0"
-        },
-        {
-            "type": "library",
-            "name": "laminas-eventmanager",
-            "version": "3.3.1",
-            "group": "laminas",
-            "description": "Trigger and listen to events within a PHP application",
-            "licenses": [
-                {
-                    "license": {
-                        "id": "BSD-3-Clause"
-                    }
-                }
-            ],
-            "purl": "pkg:composer\/laminas\/laminas-eventmanager@3.3.1"
-        },
-        {
-            "type": "library",
-            "name": "laminas-zendframework-bridge",
-            "version": "1.2.0",
-            "group": "laminas",
-            "description": "Alias legacy ZF class names to Laminas Project equivalents.",
-            "licenses": [
-                {
-                    "license": {
-                        "id": "BSD-3-Clause"
-                    }
-                }
-            ],
-            "purl": "pkg:composer\/laminas\/laminas-zendframework-bridge@1.2.0"
+            "purl": "pkg:composer\/laminas\/laminas-code@4.4.2"
         },
         {
             "type": "library",
@@ -425,23 +412,8 @@
         },
         {
             "type": "library",
-            "name": "runtime",
-            "version": "5.3.0",
-            "group": "symfony",
-            "description": "Enables decoupling PHP applications from global state",
-            "licenses": [
-                {
-                    "license": {
-                        "id": "MIT"
-                    }
-                }
-            ],
-            "purl": "pkg:composer\/symfony\/runtime@5.3.0"
-        },
-        {
-            "type": "library",
             "name": "symfony",
-            "version": "5.3.0",
+            "version": "5.3.3",
             "group": "symfony",
             "description": "The Symfony PHP framework",
             "licenses": [
@@ -451,7 +423,7 @@
                     }
                 }
             ],
-            "purl": "pkg:composer\/symfony\/symfony@5.3.0"
+            "purl": "pkg:composer\/symfony\/symfony@5.3.3"
         },
         {
             "type": "library",

--- a/demo/symfony/example-results/bom.xml
+++ b/demo/symfony/example-results/bom.xml
@@ -1,5 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bom xmlns="http://cyclonedx.org/schema/bom/1.3" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor><![CDATA[cyclonedx]]></vendor>
+        <name><![CDATA[cyclonedx-php-composer]]></name>
+        <version><![CDATA[dev-issue_14]]></version>
+      </tool>
+    </tools>
+    <component type="application">
+      <group><![CDATA[cyclonedx]]></group>
+      <name><![CDATA[cyclonedx-php-composer-demo]]></name>
+      <version><![CDATA[dev-master]]></version>
+      <description><![CDATA[demo of cyclonedx/cyclonedx-php-composer with symfony/symfony]]></description>
+      <purl><![CDATA[pkg:composer/cyclonedx/cyclonedx-php-composer-demo@dev-master]]></purl>
+    </component>
+  </metadata>
   <components>
     <component type="library">
       <group><![CDATA[doctrine]]></group>
@@ -16,14 +32,14 @@
     <component type="library">
       <group><![CDATA[doctrine]]></group>
       <name><![CDATA[cache]]></name>
-      <version><![CDATA[2.0.3]]></version>
+      <version><![CDATA[2.1.1]]></version>
       <description><![CDATA[PHP Doctrine Cache library is a popular cache implementation that supports many different drivers such as redis, memcache, apc, mongodb and others.]]></description>
       <licenses>
         <license>
           <id><![CDATA[MIT]]></id>
         </license>
       </licenses>
-      <purl><![CDATA[pkg:composer/doctrine/cache@2.0.3]]></purl>
+      <purl><![CDATA[pkg:composer/doctrine/cache@2.1.1]]></purl>
     </component>
     <component type="library">
       <group><![CDATA[doctrine]]></group>
@@ -100,38 +116,14 @@
     <component type="library">
       <group><![CDATA[laminas]]></group>
       <name><![CDATA[laminas-code]]></name>
-      <version><![CDATA[4.3.0]]></version>
+      <version><![CDATA[4.4.2]]></version>
       <description><![CDATA[Extensions to the PHP Reflection API, static code scanning, and code generation]]></description>
       <licenses>
         <license>
           <id><![CDATA[BSD-3-Clause]]></id>
         </license>
       </licenses>
-      <purl><![CDATA[pkg:composer/laminas/laminas-code@4.3.0]]></purl>
-    </component>
-    <component type="library">
-      <group><![CDATA[laminas]]></group>
-      <name><![CDATA[laminas-eventmanager]]></name>
-      <version><![CDATA[3.3.1]]></version>
-      <description><![CDATA[Trigger and listen to events within a PHP application]]></description>
-      <licenses>
-        <license>
-          <id><![CDATA[BSD-3-Clause]]></id>
-        </license>
-      </licenses>
-      <purl><![CDATA[pkg:composer/laminas/laminas-eventmanager@3.3.1]]></purl>
-    </component>
-    <component type="library">
-      <group><![CDATA[laminas]]></group>
-      <name><![CDATA[laminas-zendframework-bridge]]></name>
-      <version><![CDATA[1.2.0]]></version>
-      <description><![CDATA[Alias legacy ZF class names to Laminas Project equivalents.]]></description>
-      <licenses>
-        <license>
-          <id><![CDATA[BSD-3-Clause]]></id>
-        </license>
-      </licenses>
-      <purl><![CDATA[pkg:composer/laminas/laminas-zendframework-bridge@1.2.0]]></purl>
+      <purl><![CDATA[pkg:composer/laminas/laminas-code@4.4.2]]></purl>
     </component>
     <component type="library">
       <group><![CDATA[psr]]></group>
@@ -339,27 +331,15 @@
     </component>
     <component type="library">
       <group><![CDATA[symfony]]></group>
-      <name><![CDATA[runtime]]></name>
-      <version><![CDATA[5.3.0]]></version>
-      <description><![CDATA[Enables decoupling PHP applications from global state]]></description>
-      <licenses>
-        <license>
-          <id><![CDATA[MIT]]></id>
-        </license>
-      </licenses>
-      <purl><![CDATA[pkg:composer/symfony/runtime@5.3.0]]></purl>
-    </component>
-    <component type="library">
-      <group><![CDATA[symfony]]></group>
       <name><![CDATA[symfony]]></name>
-      <version><![CDATA[5.3.0]]></version>
+      <version><![CDATA[5.3.3]]></version>
       <description><![CDATA[The Symfony PHP framework]]></description>
       <licenses>
         <license>
           <id><![CDATA[MIT]]></id>
         </license>
       </licenses>
-      <purl><![CDATA[pkg:composer/symfony/symfony@5.3.0]]></purl>
+      <purl><![CDATA[pkg:composer/symfony/symfony@5.3.3]]></purl>
     </component>
     <component type="library">
       <group><![CDATA[twig]]></group>

--- a/src/Composer/Factories/ComponentFactory.php
+++ b/src/Composer/Factories/ComponentFactory.php
@@ -114,8 +114,7 @@ class ComponentFactory
             $license = null;
         }
 
-        // composer has no option to distinguish framework/library/application, yet
-        $type = Classification::LIBRARY;
+        $type = $this->getComponentType($package);
 
         /**
          * @psalm-suppress DocblockTypeContradiction since return value happened to be `null` for local packages
@@ -194,5 +193,18 @@ class ComponentFactory
         }
 
         return $version;
+    }
+
+    /**
+     * composer has no option to distinguish framework/library, yet.
+     * but composer knows projects and plugins, which are equivalent to application.
+     *
+     * @see https://getcomposer.org/doc/04-schema.md#type
+     */
+    private function getComponentType(PackageInterface $package): string
+    {
+        return \in_array($package->getType(), ['project', 'composer-plugin'], true)
+            ? Classification::APPLICATION
+            : Classification::LIBRARY;
     }
 }

--- a/src/Composer/ToolUpdater.php
+++ b/src/Composer/ToolUpdater.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of CycloneDX PHP Composer Plugin.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+
+namespace CycloneDX\Composer;
+
+use Composer\Repository\LockArrayRepository;
+use Composer\Semver\Constraint\MatchAllConstraint;
+use CycloneDX\Composer\Factories\ComponentFactory;
+use CycloneDX\Core\Models\Tool;
+
+/**
+ * @internal
+ *
+ * @author jkowalleck
+ */
+class ToolUpdater
+{
+    /**
+     * @var ComponentFactory
+     */
+    private $componentFactory;
+
+    public function __construct(ComponentFactory $componentFactory)
+    {
+        $this->componentFactory = $componentFactory;
+    }
+
+    /**
+     * update tool information with data based on composer lock.
+     */
+    public function updateTool(Tool $tool, LockArrayRepository $lockRepo): bool
+    {
+        $toolComposerName = sprintf(
+            '%s/%s',
+            $tool->getVendor() ?? '',
+            $tool->getName() ?? '',
+        );
+        if ('/' === $toolComposerName) {
+            return false;
+        }
+
+        $package = $lockRepo->findPackage($toolComposerName, new MatchAllConstraint());
+        if (null === $package) {
+            return false;
+        }
+
+        try {
+            $component = $this->componentFactory->makeFromPackage($package);
+        } catch (\Throwable $exception) {
+            return false;
+        }
+
+        $tool->setVersion($component->getVersion());
+        $tool->setHashRepository($component->getHashRepository());
+
+        return true;
+    }
+}

--- a/src/Core/Helpers/SimpleDomTrait.php
+++ b/src/Core/Helpers/SimpleDomTrait.php
@@ -26,7 +26,6 @@ namespace CycloneDX\Core\Helpers;
 use DOMDocument;
 use DOMElement;
 use DOMNode;
-use Generator;
 
 /**
  * @internal
@@ -81,46 +80,5 @@ trait SimpleDomTrait
         }
 
         return $element;
-    }
-
-    /**
-     * @psalm-template TCallbackReturn
-     *
-     * @psalm-template TIteratorKey as array-key
-     * @psalm-template TIteratorItem
-     *
-     * @psalm-param iterable<TIteratorKey, TIteratorItem> $items
-     * @psalm-param callable(DOMDocument, TIteratorItem, TIteratorKey=):TCallbackReturn $callback
-     *
-     * @psalm-return Generator<TIteratorKey, TCallbackReturn>
-     */
-    private function simpleDomDocumentMap(DOMDocument $document, callable $callback, iterable $items): Generator
-    {
-        foreach ($items as $key => $item) {
-            yield $key => $callback($document, $item, $key);
-        }
-    }
-
-    private function simpleDomGetAttribute(string $attribute, DOMElement $element, string $default = ''): string
-    {
-        return $element->hasAttribute($attribute)
-            ? $element->getAttribute($attribute)
-            : $default;
-    }
-
-    /**
-     * An iterator that ignores everything but {@see \DOMElement}s.
-     *
-     * Needed since `$element->getElementsByTagName()` would also find tags in nested children.
-     *
-     * @psalm-return Generator<DOMElement>
-     */
-    private function simpleDomGetChildElements(DOMElement $element): Generator
-    {
-        foreach ($element->childNodes as $childNode) {
-            if ($childNode instanceof DOMElement) {
-                yield $childNode;
-            }
-        }
     }
 }

--- a/src/Core/Models/Bom.php
+++ b/src/Core/Models/Bom.php
@@ -49,6 +49,11 @@ class Bom
      */
     private $version = 1;
 
+    /**
+     * @var MetaData|null
+     */
+    private $metaData;
+
     public function __construct(?ComponentRepository $componentRepository = null)
     {
         $this->setComponentRepository($componentRepository ?? new ComponentRepository());
@@ -101,5 +106,20 @@ class Bom
     private function isValidVersion(int $version): bool
     {
         return $version > 0;
+    }
+
+    public function getMetaData(): ?MetaData
+    {
+        return $this->metaData;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setMetaData(?MetaData $metaData): self
+    {
+        $this->metaData = $metaData;
+
+        return $this;
     }
 }

--- a/src/Core/Models/MetaData.php
+++ b/src/Core/Models/MetaData.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of CycloneDX PHP Composer Plugin.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+
+namespace CycloneDX\Core\Models;
+
+use CycloneDX\Core\Repositories\ToolRepository;
+
+/**
+ * @author jkowalleck
+ */
+class MetaData
+{
+    /**
+     * The tool(s) used in the creation of the BOM.
+     *
+     * @var ToolRepository|null
+     */
+    private $tools;
+
+    /**
+     * The component that the BOM describes.
+     *
+     * @var Component|null
+     */
+    private $component;
+
+    public function getTools(): ?ToolRepository
+    {
+        return $this->tools;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setTools(?ToolRepository $tools): self
+    {
+        $this->tools = $tools;
+
+        return $this;
+    }
+
+    public function getComponent(): ?Component
+    {
+        return $this->component;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setComponent(?Component $component): self
+    {
+        $this->component = $component;
+
+        return $this;
+    }
+}

--- a/src/Core/Models/Tool.php
+++ b/src/Core/Models/Tool.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of CycloneDX PHP Composer Plugin.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+
+namespace CycloneDX\Core\Models;
+
+use CycloneDX\Core\Repositories\HashRepository;
+
+/**
+ * @author jkowalleck
+ */
+class Tool
+{
+    /**
+     * The vendor of the tool used to create the BOM.
+     *
+     * @var string|null
+     */
+    private $vendor;
+
+    /**
+     * The name of the tool used to create the BOM.
+     *
+     * @var string|null
+     */
+    private $name;
+
+    /**
+     * The version of the tool used to create the BOM.
+     *
+     * @var string|null
+     */
+    private $version;
+
+    /**
+     * The hashes of the tool (if applicable).
+     *
+     * @var HashRepository|null
+     */
+    private $hashRepository;
+
+    public function getVendor(): ?string
+    {
+        return $this->vendor;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setVendor(?string $vendor): self
+    {
+        $this->vendor = $vendor;
+
+        return $this;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setName(?string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getVersion(): ?string
+    {
+        return $this->version;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setVersion(?string $version): self
+    {
+        $this->version = $version;
+
+        return $this;
+    }
+
+    public function getHashRepository(): ?HashRepository
+    {
+        return $this->hashRepository;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setHashRepository(?HashRepository $hashRepository): self
+    {
+        $this->hashRepository = $hashRepository;
+
+        return $this;
+    }
+}

--- a/src/Core/Repositories/ToolRepository.php
+++ b/src/Core/Repositories/ToolRepository.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of CycloneDX PHP Composer Plugin.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+
+namespace CycloneDX\Core\Repositories;
+
+use CycloneDX\Core\Models\Tool;
+
+/**
+ * @author jkowalleck
+ */
+class ToolRepository implements \Countable
+{
+    /**
+     * @var Tool[]
+     * @psalm-var list<Tool>
+     */
+    private $tools = [];
+
+    public function __construct(Tool ...$tools)
+    {
+        $this->addTool(...$tools);
+    }
+
+    /**
+     * @return $this
+     */
+    public function addTool(Tool ...$tools): self
+    {
+        array_push($this->tools, ...array_values($tools));
+
+        return $this;
+    }
+
+    /**
+     * @return Tool[]
+     * @psalm-return list<Tool>
+     */
+    public function getTools(): array
+    {
+        return $this->tools;
+    }
+
+    public function count(): int
+    {
+        return \count($this->tools);
+    }
+}

--- a/src/Core/Serialize/DOM/NormalizerFactory.php
+++ b/src/Core/Serialize/DOM/NormalizerFactory.php
@@ -23,14 +23,6 @@ declare(strict_types=1);
 
 namespace CycloneDX\Core\Serialize\DOM;
 
-use CycloneDX\Core\Serialize\DOM\Normalizers\BomNormalizer;
-use CycloneDX\Core\Serialize\DOM\Normalizers\ComponentNormalizer;
-use CycloneDX\Core\Serialize\DOM\Normalizers\ComponentRepositoryNormalizer;
-use CycloneDX\Core\Serialize\DOM\Normalizers\DisjunctiveLicenseNormalizer;
-use CycloneDX\Core\Serialize\DOM\Normalizers\DisjunctiveLicenseRepositoryNormalizer;
-use CycloneDX\Core\Serialize\DOM\Normalizers\HashNormalizer;
-use CycloneDX\Core\Serialize\DOM\Normalizers\HashRepositoryNormalizer;
-use CycloneDX\Core\Serialize\DOM\Normalizers\LicenseExpressionNormalizer;
 use CycloneDX\Core\Spec\Format;
 use CycloneDX\Core\Spec\SpecInterface;
 use DomainException;
@@ -86,43 +78,58 @@ class NormalizerFactory
         return $this->document;
     }
 
-    public function makeForBom(): BomNormalizer
+    public function makeForBom(): Normalizers\BomNormalizer
     {
-        return new BomNormalizer($this);
+        return new Normalizers\BomNormalizer($this);
     }
 
-    public function makeForComponentRepository(): ComponentRepositoryNormalizer
+    public function makeForComponentRepository(): Normalizers\ComponentRepositoryNormalizer
     {
-        return new ComponentRepositoryNormalizer($this);
+        return new Normalizers\ComponentRepositoryNormalizer($this);
     }
 
-    public function makeForComponent(): ComponentNormalizer
+    public function makeForComponent(): Normalizers\ComponentNormalizer
     {
-        return new ComponentNormalizer($this);
+        return new Normalizers\ComponentNormalizer($this);
     }
 
-    public function makeForLicenseExpression(): LicenseExpressionNormalizer
+    public function makeForLicenseExpression(): Normalizers\LicenseExpressionNormalizer
     {
-        return new LicenseExpressionNormalizer($this);
+        return new Normalizers\LicenseExpressionNormalizer($this);
     }
 
-    public function makeForDisjunctiveLicenseRepository(): DisjunctiveLicenseRepositoryNormalizer
+    public function makeForDisjunctiveLicenseRepository(): Normalizers\DisjunctiveLicenseRepositoryNormalizer
     {
-        return new DisjunctiveLicenseRepositoryNormalizer($this);
+        return new Normalizers\DisjunctiveLicenseRepositoryNormalizer($this);
     }
 
-    public function makeForDisjunctiveLicense(): DisjunctiveLicenseNormalizer
+    public function makeForDisjunctiveLicense(): Normalizers\DisjunctiveLicenseNormalizer
     {
-        return new DisjunctiveLicenseNormalizer($this);
+        return new Normalizers\DisjunctiveLicenseNormalizer($this);
     }
 
-    public function makeForHashRepository(): HashRepositoryNormalizer
+    public function makeForHashRepository(): Normalizers\HashRepositoryNormalizer
     {
-        return new HashRepositoryNormalizer($this);
+        return new Normalizers\HashRepositoryNormalizer($this);
     }
 
-    public function makeForHash(): HashNormalizer
+    public function makeForHash(): Normalizers\HashNormalizer
     {
-        return new HashNormalizer($this);
+        return new Normalizers\HashNormalizer($this);
+    }
+
+    public function makeForMetaData(): Normalizers\MetaDataNormalizer
+    {
+        return new Normalizers\MetaDataNormalizer($this);
+    }
+
+    public function makeForToolRepository(): Normalizers\ToolRepositoryNormalizer
+    {
+        return new Normalizers\ToolRepositoryNormalizer($this);
+    }
+
+    public function makeForTool(): Normalizers\ToolNormalizer
+    {
+        return new Normalizers\ToolNormalizer($this);
     }
 }

--- a/src/Core/Serialize/DOM/Normalizers/ComponentNormalizer.php
+++ b/src/Core/Serialize/DOM/Normalizers/ComponentNormalizer.php
@@ -58,11 +58,11 @@ class ComponentNormalizer extends AbstractNormalizer
 
         $document = $this->getNormalizerFactory()->getDocument();
 
-        $element = $document->createElement('component');
-        $this->simpleDomSetAttributes($element, ['type' => $type]);
-
         return $this->simpleDomAppendChildren(
-            $element,
+            $this->simpleDomSetAttributes(
+                $document->createElement('component'),
+                ['type' => $type]
+            ),
             [
                 // publisher
                 $this->simpleDomSafeTextElement($document, 'group', $group),
@@ -85,8 +85,6 @@ class ComponentNormalizer extends AbstractNormalizer
 
     /**
      * @param LicenseExpression|DisjunctiveLicenseRepository|null $license
-     *
-     * @throws DomainException
      */
     private function normalizeLicense($license): ?DOMElement
     {

--- a/src/Core/Serialize/DOM/Normalizers/ComponentRepositoryNormalizer.php
+++ b/src/Core/Serialize/DOM/Normalizers/ComponentRepositoryNormalizer.php
@@ -36,13 +36,19 @@ class ComponentRepositoryNormalizer extends AbstractNormalizer
      * @return DOMElement[]
      * @psalm-return list<DOMElement>
      */
-    public function normalize(ComponentRepository $components): array
+    public function normalize(ComponentRepository $repo): array
     {
-        return 0 === \count($components)
-            ? []
-            : array_map(
-                [$this->getNormalizerFactory()->makeForComponent(), 'normalize'],
-                $components->getComponents()
-            );
+        $normalizer = $this->getNormalizerFactory()->makeForComponent();
+
+        $components = [];
+        foreach ($repo->getComponents() as $component) {
+            try {
+                $components[] = $normalizer->normalize($component);
+            } catch (\DomainException $exception) {
+                continue;
+            }
+        }
+
+        return $components;
     }
 }

--- a/src/Core/Serialize/DOM/Normalizers/HashNormalizer.php
+++ b/src/Core/Serialize/DOM/Normalizers/HashNormalizer.php
@@ -48,7 +48,11 @@ class HashNormalizer extends AbstractNormalizer
             throw new DomainException("Invalid hash content: $content", 2);
         }
 
-        $element = $this->simpleDomSafeTextElement($this->getNormalizerFactory()->getDocument(), 'hash', $content);
+        $element = $this->simpleDomSafeTextElement(
+            $this->getNormalizerFactory()->getDocument(),
+            'hash',
+            $content
+        );
         \assert(null !== $element);
         $this->simpleDomSetAttributes($element, ['alg' => $algorithm]);
 

--- a/src/Core/Serialize/DOM/Normalizers/LicenseExpressionNormalizer.php
+++ b/src/Core/Serialize/DOM/Normalizers/LicenseExpressionNormalizer.php
@@ -37,7 +37,11 @@ class LicenseExpressionNormalizer extends AbstractNormalizer
 
     public function normalize(LicenseExpression $license): DOMElement
     {
-        $element = $this->simpleDomSafeTextElement($this->getNormalizerFactory()->getDocument(), 'expression', $license->getExpression());
+        $element = $this->simpleDomSafeTextElement(
+            $this->getNormalizerFactory()->getDocument(),
+            'expression',
+            $license->getExpression()
+        );
         \assert(null !== $element);
 
         return $element;

--- a/src/Core/Serialize/DOM/Normalizers/MetaDataNormalizer.php
+++ b/src/Core/Serialize/DOM/Normalizers/MetaDataNormalizer.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of CycloneDX PHP Composer Plugin.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+
+namespace CycloneDX\Core\Serialize\DOM\Normalizers;
+
+use CycloneDX\Core\Helpers\SimpleDomTrait;
+use CycloneDX\Core\Models\Component;
+use CycloneDX\Core\Models\MetaData;
+use CycloneDX\Core\Repositories\ToolRepository;
+use CycloneDX\Core\Serialize\DOM\AbstractNormalizer;
+use DOMElement;
+
+/**
+ * @author jkowalleck
+ */
+class MetaDataNormalizer extends AbstractNormalizer
+{
+    use SimpleDomTrait;
+
+    public function normalize(MetaData $metaData): DOMElement
+    {
+        return $this->simpleDomAppendChildren(
+            $this->getNormalizerFactory()->getDocument()->createElement('metadata'),
+            [
+                // timestamp
+                $this->normalizeTools($metaData->getTools()),
+                // authors
+                $this->normalizeComponent($metaData->getComponent()),
+                // manufacture
+                // supplier
+            ]
+        );
+    }
+
+    private function normalizeTools(?ToolRepository $tools): ?DOMElement
+    {
+        return null === $tools || 0 === \count($tools)
+            ? null
+            : $this->simpleDomAppendChildren(
+                $this->getNormalizerFactory()->getDocument()->createElement('tools'),
+                $this->getNormalizerFactory()->makeForToolRepository()->normalize($tools)
+            );
+    }
+
+    private function normalizeComponent(?Component $component): ?DOMElement
+    {
+        if (null === $component) {
+            return null;
+        }
+
+        try {
+            return $this->getNormalizerFactory()->makeForComponent()->normalize($component);
+        } catch (\DomainException $exception) {
+            return null;
+        }
+    }
+}

--- a/src/Core/Serialize/DOM/Normalizers/ToolNormalizer.php
+++ b/src/Core/Serialize/DOM/Normalizers/ToolNormalizer.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of CycloneDX PHP Composer Plugin.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+
+namespace CycloneDX\Core\Serialize\DOM\Normalizers;
+
+use CycloneDX\Core\Helpers\SimpleDomTrait;
+use CycloneDX\Core\Models\Tool;
+use CycloneDX\Core\Repositories\HashRepository;
+use CycloneDX\Core\Serialize\DOM\AbstractNormalizer;
+use DOMElement;
+
+/**
+ * @author jkowalleck
+ */
+class ToolNormalizer extends AbstractNormalizer
+{
+    use SimpleDomTrait;
+
+    public function normalize(Tool $tool): DOMElement
+    {
+        $doc = $this->getNormalizerFactory()->getDocument();
+
+        return $this->simpleDomAppendChildren(
+            $doc->createElement('tool'),
+            [
+                $this->simpleDomSafeTextElement($doc, 'vendor', $tool->getVendor()),
+                $this->simpleDomSafeTextElement($doc, 'name', $tool->getName()),
+                $this->simpleDomSafeTextElement($doc, 'version', $tool->getVersion()),
+                $this->normalizeHashes($tool->getHashRepository()),
+            ]
+        );
+    }
+
+    private function normalizeHashes(?HashRepository $hashes): ?DOMElement
+    {
+        return null === $hashes || 0 === \count($hashes)
+            ? null
+            : $this->simpleDomAppendChildren(
+                $this->getNormalizerFactory()->getDocument()->createElement('hashes'),
+                $this->getNormalizerFactory()->makeForHashRepository()->normalize($hashes)
+            );
+    }
+}

--- a/src/Core/Serialize/DOM/Normalizers/ToolRepositoryNormalizer.php
+++ b/src/Core/Serialize/DOM/Normalizers/ToolRepositoryNormalizer.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of CycloneDX PHP Composer Plugin.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+
+namespace CycloneDX\Core\Serialize\DOM\Normalizers;
+
+use CycloneDX\Core\Repositories\ToolRepository;
+use CycloneDX\Core\Serialize\DOM\AbstractNormalizer;
+use DOMElement;
+
+/**
+ * @author jkowalleck
+ */
+class ToolRepositoryNormalizer extends AbstractNormalizer
+{
+    /**
+     * @return DOMElement[]
+     * @psalm-return list<DOMElement>
+     */
+    public function normalize(ToolRepository $repo): array
+    {
+        $normalizer = $this->getNormalizerFactory()->makeForTool();
+
+        $tools = [];
+        foreach ($repo->getTools() as $tool) {
+            try {
+                $tools[] = $normalizer->normalize($tool);
+            } catch (\DomainException $exception) {
+                continue;
+            }
+        }
+
+        return $tools;
+    }
+}

--- a/src/Core/Serialize/JSON/NormalizerFactory.php
+++ b/src/Core/Serialize/JSON/NormalizerFactory.php
@@ -23,14 +23,6 @@ declare(strict_types=1);
 
 namespace CycloneDX\Core\Serialize\JSON;
 
-use CycloneDX\Core\Serialize\JSON\Normalizers\BomNormalizer;
-use CycloneDX\Core\Serialize\JSON\Normalizers\ComponentNormalizer;
-use CycloneDX\Core\Serialize\JSON\Normalizers\ComponentRepositoryNormalizer;
-use CycloneDX\Core\Serialize\JSON\Normalizers\DisjunctiveLicenseNormalizer;
-use CycloneDX\Core\Serialize\JSON\Normalizers\DisjunctiveLicenseRepositoryNormalizer;
-use CycloneDX\Core\Serialize\JSON\Normalizers\HashNormalizer;
-use CycloneDX\Core\Serialize\JSON\Normalizers\HashRepositoryNormalizer;
-use CycloneDX\Core\Serialize\JSON\Normalizers\LicenseExpressionNormalizer;
 use CycloneDX\Core\Spec\Format;
 use CycloneDX\Core\Spec\SpecInterface;
 use DomainException;
@@ -62,7 +54,7 @@ class NormalizerFactory
     }
 
     /**
-     * @throws DomainException when the spec does not support XML format
+     * @throws DomainException when the spec does not support JSON format
      *
      * @return $this
      */
@@ -76,43 +68,58 @@ class NormalizerFactory
         return $this;
     }
 
-    public function makeForBom(): BomNormalizer
+    public function makeForBom(): Normalizers\BomNormalizer
     {
-        return new BomNormalizer($this);
+        return new Normalizers\BomNormalizer($this);
     }
 
-    public function makeForComponentRepository(): ComponentRepositoryNormalizer
+    public function makeForComponentRepository(): Normalizers\ComponentRepositoryNormalizer
     {
-        return new ComponentRepositoryNormalizer($this);
+        return new Normalizers\ComponentRepositoryNormalizer($this);
     }
 
-    public function makeForComponent(): ComponentNormalizer
+    public function makeForComponent(): Normalizers\ComponentNormalizer
     {
-        return new ComponentNormalizer($this);
+        return new Normalizers\ComponentNormalizer($this);
     }
 
-    public function makeForLicenseExpression(): LicenseExpressionNormalizer
+    public function makeForLicenseExpression(): Normalizers\LicenseExpressionNormalizer
     {
-        return new LicenseExpressionNormalizer($this);
+        return new Normalizers\LicenseExpressionNormalizer($this);
     }
 
-    public function makeForDisjunctiveLicenseRepository(): DisjunctiveLicenseRepositoryNormalizer
+    public function makeForDisjunctiveLicenseRepository(): Normalizers\DisjunctiveLicenseRepositoryNormalizer
     {
-        return new DisjunctiveLicenseRepositoryNormalizer($this);
+        return new Normalizers\DisjunctiveLicenseRepositoryNormalizer($this);
     }
 
-    public function makeForDisjunctiveLicense(): DisjunctiveLicenseNormalizer
+    public function makeForDisjunctiveLicense(): Normalizers\DisjunctiveLicenseNormalizer
     {
-        return new DisjunctiveLicenseNormalizer($this);
+        return new Normalizers\DisjunctiveLicenseNormalizer($this);
     }
 
-    public function makeForHashRepository(): HashRepositoryNormalizer
+    public function makeForHashRepository(): Normalizers\HashRepositoryNormalizer
     {
-        return new HashRepositoryNormalizer($this);
+        return new Normalizers\HashRepositoryNormalizer($this);
     }
 
-    public function makeForHash(): HashNormalizer
+    public function makeForHash(): Normalizers\HashNormalizer
     {
-        return new HashNormalizer($this);
+        return new Normalizers\HashNormalizer($this);
+    }
+
+    public function makeForMetaData(): Normalizers\MetaDataNormalizer
+    {
+        return new Normalizers\MetaDataNormalizer($this);
+    }
+
+    public function makeForToolRepository(): Normalizers\ToolRepositoryNormalizer
+    {
+        return new Normalizers\ToolRepositoryNormalizer($this);
+    }
+
+    public function makeForTool(): Normalizers\ToolNormalizer
+    {
+        return new Normalizers\ToolNormalizer($this);
     }
 }

--- a/src/Core/Serialize/JSON/Normalizers/ComponentNormalizer.php
+++ b/src/Core/Serialize/JSON/Normalizers/ComponentNormalizer.php
@@ -42,8 +42,6 @@ class ComponentNormalizer extends AbstractNormalizer
 
     /**
      * @throws DomainException
-     *
-     * @psalm-return array<string, mixed>
      */
     public function normalize(Component $component): array
     {

--- a/src/Core/Serialize/JSON/Normalizers/ComponentRepositoryNormalizer.php
+++ b/src/Core/Serialize/JSON/Normalizers/ComponentRepositoryNormalizer.php
@@ -34,13 +34,19 @@ class ComponentRepositoryNormalizer extends AbstractNormalizer
     /**
      * @psalm-return list<mixed>
      */
-    public function normalize(ComponentRepository $components): array
+    public function normalize(ComponentRepository $repo): array
     {
-        return 0 === \count($components)
-            ? []
-            : array_map(
-                [$this->getNormalizerFactory()->makeForComponent(), 'normalize'],
-                $components->getComponents()
-            );
+        $components = [];
+
+        $normalizer = $this->getNormalizerFactory()->makeForComponent();
+        foreach ($repo->getComponents() as $component) {
+            try {
+                $components[] = $normalizer->normalize($component);
+            } catch (\DomainException $exception) {
+                continue;
+            }
+        }
+
+        return $components;
     }
 }

--- a/src/Core/Serialize/JSON/Normalizers/DisjunctiveLicenseNormalizer.php
+++ b/src/Core/Serialize/JSON/Normalizers/DisjunctiveLicenseNormalizer.php
@@ -41,8 +41,6 @@ class DisjunctiveLicenseNormalizer extends AbstractNormalizer
      * @psalm-assert DisjunctiveLicenseWithId|DisjunctiveLicenseWithName $license
      *
      * @throws InvalidArgumentException
-     *
-     * @psalm-return array{'license': array<string, mixed>}
      */
     public function normalize(AbstractDisjunctiveLicense $license): array
     {

--- a/src/Core/Serialize/JSON/Normalizers/DisjunctiveLicenseRepositoryNormalizer.php
+++ b/src/Core/Serialize/JSON/Normalizers/DisjunctiveLicenseRepositoryNormalizer.php
@@ -25,7 +25,6 @@ namespace CycloneDX\Core\Serialize\JSON\Normalizers;
 
 use CycloneDX\Core\Repositories\DisjunctiveLicenseRepository;
 use CycloneDX\Core\Serialize\JSON\AbstractNormalizer;
-use DomainException;
 use InvalidArgumentException;
 
 /**
@@ -33,17 +32,19 @@ use InvalidArgumentException;
  */
 class DisjunctiveLicenseRepositoryNormalizer extends AbstractNormalizer
 {
-    /**
-     * @throws DomainException
-     */
     public function normalize(DisjunctiveLicenseRepository $repo): array
     {
+        $licenses = [];
+
         $normalizer = $this->getNormalizerFactory()->makeForDisjunctiveLicense();
-        $licenses = $repo->getLicenses();
-        try {
-            return array_map([$normalizer, 'normalize'], $licenses);
-        } catch (InvalidArgumentException $exception) {
-            throw new DomainException('Unsupported license detected', 0, $exception);
+        foreach ($repo->getLicenses() as $license) {
+            try {
+                $licenses[] = $normalizer->normalize($license);
+            } catch (InvalidArgumentException $exception) {
+                continue;
+            }
         }
+
+        return $licenses;
     }
 }

--- a/src/Core/Serialize/JSON/Normalizers/HashRepositoryNormalizer.php
+++ b/src/Core/Serialize/JSON/Normalizers/HashRepositoryNormalizer.php
@@ -25,24 +25,25 @@ namespace CycloneDX\Core\Serialize\JSON\Normalizers;
 
 use CycloneDX\Core\Repositories\HashRepository;
 use CycloneDX\Core\Serialize\JSON\AbstractNormalizer;
-use DomainException;
 
 /**
  * @author jkowalleck
  */
 class HashRepositoryNormalizer extends AbstractNormalizer
 {
-    /**
-     * @throws DomainException
-     */
     public function normalize(HashRepository $repo): array
     {
-        $hashes = $repo->getHashes();
+        $hashes = [];
 
-        return array_map(
-            [$this->getNormalizerFactory()->makeForHash(), 'normalize'],
-            array_keys($hashes),
-            array_values($hashes)
-        );
+        $normalizer = $this->getNormalizerFactory()->makeForHash();
+        foreach ($repo->getHashes() as $algorithm => $content) {
+            try {
+                $hashes[] = $normalizer->normalize($algorithm, $content);
+            } catch (\DomainException $exception) {
+                continue;
+            }
+        }
+
+        return $hashes;
     }
 }

--- a/src/Core/Serialize/JSON/Normalizers/LicenseExpressionNormalizer.php
+++ b/src/Core/Serialize/JSON/Normalizers/LicenseExpressionNormalizer.php
@@ -31,9 +31,6 @@ use CycloneDX\Core\Serialize\JSON\AbstractNormalizer;
  */
 class LicenseExpressionNormalizer extends AbstractNormalizer
 {
-    /**
-     * @psalm-return array{'expression': string}
-     */
     public function normalize(LicenseExpression $license): array
     {
         return ['expression' => $license->getExpression()];

--- a/src/Core/Serialize/JSON/Normalizers/MetaDataNormalizer.php
+++ b/src/Core/Serialize/JSON/Normalizers/MetaDataNormalizer.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of CycloneDX PHP Composer Plugin.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+
+namespace CycloneDX\Core\Serialize\JSON\Normalizers;
+
+use CycloneDX\Core\Helpers\NullAssertionTrait;
+use CycloneDX\Core\Models\Component;
+use CycloneDX\Core\Models\MetaData;
+use CycloneDX\Core\Repositories\ToolRepository;
+use CycloneDX\Core\Serialize\JSON\AbstractNormalizer;
+
+/**
+ * @author jkowalleck
+ */
+class MetaDataNormalizer extends AbstractNormalizer
+{
+    use NullAssertionTrait;
+
+    public function normalize(MetaData $metaData): array
+    {
+        return array_filter(
+            [
+                // timestamp
+                'tools' => $this->normalizeTools($metaData->getTools()),
+                // authors
+                'component' => $this->normalizeComponent($metaData->getComponent()),
+                // manufacture
+                // supplier
+            ],
+            [$this, 'isNotNull']
+        );
+    }
+
+    private function normalizeTools(?ToolRepository $tools): ?array
+    {
+        return null === $tools || 0 === \count($tools)
+            ? null
+            : $this->getNormalizerFactory()->makeForToolRepository()->normalize($tools);
+    }
+
+    private function normalizeComponent(?Component $component): ?array
+    {
+        if (null === $component) {
+            return null;
+        }
+
+        try {
+            return $this->getNormalizerFactory()->makeForComponent()->normalize($component);
+        } catch (\DomainException $exception) {
+            return null;
+        }
+    }
+}

--- a/src/Core/Serialize/JSON/Normalizers/ToolNormalizer.php
+++ b/src/Core/Serialize/JSON/Normalizers/ToolNormalizer.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of CycloneDX PHP Composer Plugin.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+
+namespace CycloneDX\Core\Serialize\JSON\Normalizers;
+
+use CycloneDX\Core\Helpers\NullAssertionTrait;
+use CycloneDX\Core\Models\Tool;
+use CycloneDX\Core\Repositories\HashRepository;
+use CycloneDX\Core\Serialize\JSON\AbstractNormalizer;
+
+/**
+ * @author jkowalleck
+ */
+class ToolNormalizer extends AbstractNormalizer
+{
+    use NullAssertionTrait;
+
+    public function normalize(Tool $tool): array
+    {
+        return array_filter(
+            [
+                'vendor' => $tool->getVendor(),
+                'name' => $tool->getName(),
+                'version' => $tool->getVersion(),
+                'hashes' => $this->normalizeHashes($tool->getHashRepository()),
+            ],
+            [$this, 'isNotNull']
+        );
+    }
+
+    private function normalizeHashes(?HashRepository $hashes): ?array
+    {
+        return null === $hashes || 0 === \count($hashes)
+            ? null
+            : $this->getNormalizerFactory()->makeForHashRepository()->normalize($hashes);
+    }
+}

--- a/src/Core/Serialize/JSON/Normalizers/ToolRepositoryNormalizer.php
+++ b/src/Core/Serialize/JSON/Normalizers/ToolRepositoryNormalizer.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of CycloneDX PHP Composer Plugin.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+
+namespace CycloneDX\Core\Serialize\JSON\Normalizers;
+
+use CycloneDX\Core\Repositories\ToolRepository;
+use CycloneDX\Core\Serialize\JSON\AbstractNormalizer;
+
+/**
+ * @author jkowalleck
+ */
+class ToolRepositoryNormalizer extends AbstractNormalizer
+{
+    /**
+     * @return array[]
+     * @psalm-return list<array>
+     */
+    public function normalize(ToolRepository $repo): array
+    {
+        $normalizer = $this->getNormalizerFactory()->makeForTool();
+
+        $tools = [];
+        foreach ($repo->getTools() as $tool) {
+            try {
+                $item = $normalizer->normalize($tool);
+            } catch (\DomainException $exception) {
+                continue;
+            }
+            if (false === empty($item)) {
+                $tools[] = $item;
+            }
+        }
+
+        return $tools;
+    }
+}

--- a/src/Core/Serialize/JsonSerializer.php
+++ b/src/Core/Serialize/JsonSerializer.php
@@ -25,7 +25,6 @@ namespace CycloneDX\Core\Serialize;
 
 use CycloneDX\Core\Helpers\HasSpecTrait;
 use CycloneDX\Core\Models\Bom;
-use CycloneDX\Core\Serialize\JSON\NormalizerFactory;
 use CycloneDX\Core\Spec\SpecInterface;
 use DomainException;
 
@@ -53,7 +52,7 @@ class JsonSerializer implements SerializerInterface
         $options = \JSON_THROW_ON_ERROR | \JSON_PRESERVE_ZERO_FRACTION | \JSON_PRETTY_PRINT;
 
         $json = json_encode(
-            (new NormalizerFactory($this->spec))
+            (new JSON\NormalizerFactory($this->spec))
                 ->makeForBom()
                 ->normalize($bom),
             $options

--- a/src/Core/Serialize/XmlSerializer.php
+++ b/src/Core/Serialize/XmlSerializer.php
@@ -26,7 +26,6 @@ namespace CycloneDX\Core\Serialize;
 use CycloneDX\Core\Helpers\HasSpecTrait;
 use CycloneDX\Core\Helpers\SimpleDomTrait;
 use CycloneDX\Core\Models\Bom;
-use CycloneDX\Core\Serialize\DOM\NormalizerFactory;
 use CycloneDX\Core\Spec\SpecInterface;
 use DomainException;
 use DOMDocument;
@@ -57,7 +56,7 @@ class XmlSerializer implements SerializerInterface
         $document = new DOMDocument(self::XML_VERSION, self::XML_ENCODING);
         $document->appendChild(
             $document->importNode(
-                (new NormalizerFactory($this->spec))
+                (new DOM\NormalizerFactory($this->spec))
                     ->makeForBom()
                     ->normalize($bom),
                 true

--- a/src/Core/Spec/Spec11.php
+++ b/src/Core/Spec/Spec11.php
@@ -64,4 +64,9 @@ final class Spec11 implements SpecInterface
     {
         return true;
     }
+
+    public function supportsMetaData(): bool
+    {
+        return false;
+    }
 }

--- a/src/Core/Spec/Spec12.php
+++ b/src/Core/Spec/Spec12.php
@@ -72,4 +72,9 @@ final class Spec12 implements SpecInterface
     {
         return true;
     }
+
+    public function supportsMetaData(): bool
+    {
+        return true;
+    }
 }

--- a/src/Core/Spec/Spec13.php
+++ b/src/Core/Spec/Spec13.php
@@ -72,4 +72,9 @@ final class Spec13 implements SpecInterface
     {
         return true;
     }
+
+    public function supportsMetaData(): bool
+    {
+        return true;
+    }
 }

--- a/src/Core/Spec/SpecInterface.php
+++ b/src/Core/Spec/SpecInterface.php
@@ -67,4 +67,9 @@ interface SpecInterface
      * they must be normalized to disjunctive licenses.
      */
     public function supportsLicenseExpression(): bool;
+
+    /**
+     * version < 1.2 does not support MetaData.
+     */
+    public function supportsMetaData(): bool;
 }

--- a/tests/Composer/Factories/BomFactoryTest.php
+++ b/tests/Composer/Factories/BomFactoryTest.php
@@ -27,6 +27,7 @@ use Composer\Package\PackageInterface;
 use Composer\Repository\LockArrayRepository;
 use CycloneDX\Composer\Factories\BomFactory;
 use CycloneDX\Composer\Factories\ComponentFactory;
+use CycloneDX\Core\Models\Tool;
 use CycloneDX\Core\Repositories\ComponentRepository;
 use PHPUnit\Framework\TestCase;
 
@@ -35,8 +36,22 @@ use PHPUnit\Framework\TestCase;
  */
 class BomFactoryTest extends TestCase
 {
+    public function testConstruct(): BomFactory
+    {
+        $componentFactory = $this->createMock(ComponentFactory::class);
+        $tool = $this->createMock(Tool::class);
+
+        $factory = new BomFactory($componentFactory, $tool);
+
+        self::assertSame($componentFactory, $factory->getComponentFactory());
+        self::assertSame($tool, $factory->getTool());
+
+        return $factory;
+    }
+
     /**
      * @uses \CycloneDX\Core\Models\Bom
+     * @uses \CycloneDX\Core\Models\MetaData
      */
     public function testMakeForPackageWithComponents(): void
     {

--- a/tests/Composer/Factories/ComponentFactoryTest.php
+++ b/tests/Composer/Factories/ComponentFactoryTest.php
@@ -110,16 +110,60 @@ class ComponentFactoryTest extends TestCase
 
     public function dpMakeFromPackage(): \Generator
     {
-        yield 'minimal package' => [
+        yield 'minimal library' => [
             $this->createConfiguredMock(
                 PackageInterface::class,
                 [
-                    'getPrettyName' => 'some-package',
-                    'getPrettyVersion' => 'v1.2.3',
+                    'getType' => 'library',
+                    'getPrettyName' => 'some-library',
+                    'getPrettyVersion' => '1.2.3',
                 ],
             ),
-            (new Component('library', 'some-package', '1.2.3'))
-                ->setPackageUrl((new PackageUrl('composer', 'some-package'))->setVersion('1.2.3')),
+            (new Component('library', 'some-library', '1.2.3'))
+                ->setPackageUrl((new PackageUrl('composer', 'some-library'))->setVersion('1.2.3')),
+            null,
+        ];
+
+        yield 'minimal project' => [
+            $this->createConfiguredMock(
+                PackageInterface::class,
+                [
+                    'getType' => 'project',
+                    'getPrettyName' => 'some-project',
+                    'getPrettyVersion' => '1.2.3',
+                ],
+            ),
+            (new Component('application', 'some-project', '1.2.3'))
+                ->setPackageUrl((new PackageUrl('composer', 'some-project'))->setVersion('1.2.3')),
+            null,
+        ];
+
+        yield 'minimal composer-plugin' => [
+            $this->createConfiguredMock(
+                PackageInterface::class,
+                [
+                    'getType' => 'composer-plugin',
+                    'getPrettyName' => 'some-composer-plugin',
+                    'getPrettyVersion' => '1.2.3',
+                ],
+            ),
+            (new Component('application', 'some-composer-plugin', '1.2.3'))
+                ->setPackageUrl((new PackageUrl('composer', 'some-composer-plugin'))->setVersion('1.2.3')),
+            null,
+        ];
+
+        yield 'minimal inDev of unknown type' => [
+            $this->createConfiguredMock(
+                PackageInterface::class,
+                [
+                    'getType' => 'myTye',
+                    'getPrettyName' => 'some-inDev',
+                    'getPrettyVersion' => 'dev-master',
+                    'isDev' => true,
+                ],
+            ),
+            (new Component('library', 'some-inDev', 'dev-master'))
+                ->setPackageUrl((new PackageUrl('composer', 'some-inDev'))->setVersion('dev-master')),
             null,
         ];
 
@@ -127,11 +171,10 @@ class ComponentFactoryTest extends TestCase
             CompletePackageInterface::class,
             [
                 'getPrettyName' => 'my/package',
-                'getPrettyVersion' => 'dev-master',
-                'isDev' => true,
+                'getPrettyVersion' => 'v1.2.3',
                 'getDescription' => 'my description',
                 'getLicense' => ['MIT'],
-                'getDistSha1Checksum' => '1234567890',
+                'getDistSha1Checksum' => '12345678901234567890123456789012',
             ]
         );
         $license = $this->createStub(DisjunctiveLicenseRepository::class);
@@ -139,19 +182,19 @@ class ComponentFactoryTest extends TestCase
         $licenseFactory->expects(self::once())->method('makeFromPackage')
             ->with($completePackage)
             ->willReturn($license);
-        yield 'complete package' => [
+        yield 'complete library' => [
             $completePackage,
-            (new Component('library', 'package', 'dev-master'))
+            (new Component('library', 'package', '1.2.3'))
                 ->setGroup('my')
                 ->setPackageUrl(
                     (new PackageUrl('composer', 'package'))
                         ->setNamespace('my')
-                        ->setVersion('dev-master')
-                        ->setChecksums(['sha1:1234567890'])
+                        ->setVersion('1.2.3')
+                        ->setChecksums(['sha1:12345678901234567890123456789012'])
                 )
                 ->setDescription('my description')
                 ->setLicense($license)
-                ->setHashRepository(new HashRepository([HashAlgorithm::SHA_1 => '1234567890'])),
+                ->setHashRepository(new HashRepository([HashAlgorithm::SHA_1 => '12345678901234567890123456789012'])),
             $licenseFactory,
         ];
     }

--- a/tests/Composer/MakeBom/CommandTest.php
+++ b/tests/Composer/MakeBom/CommandTest.php
@@ -67,7 +67,7 @@ class CommandTest extends TestCase
         $this->options = $this->createTestProxy(Options::class);
         $this->factory = $this->createMock(Factory::class);
         $this->bomFactory = $this->createMock(BomFactory::class);
-        $this->command = new Command($this->options, $this->factory, $this->bomFactory, 'test-dummy');
+        $this->command = new Command($this->options, $this->factory, $this->bomFactory, null, 'test-dummy');
         $this->command->setIO(new NullIO());
     }
 
@@ -77,7 +77,7 @@ class CommandTest extends TestCase
             ->method('configureCommand')
             ->with(new IsInstanceOf(Command::class));
 
-        new Command($this->options, $this->factory, $this->bomFactory, 'test-dummy');
+        new Command($this->options, $this->factory, $this->bomFactory, null, 'test-dummy');
     }
 
     public function testRunFailsWhenOptionsInvalid(): void

--- a/tests/Composer/PluginTest.php
+++ b/tests/Composer/PluginTest.php
@@ -78,8 +78,11 @@ class PluginTest extends TestCase
 
     /**
      * @depends testPluginIsRegistered
+     *
+     * @return PluginInterface|Capable
+     * @psalm-return PluginInterface&Capable
      */
-    public function testPluginImplementsRequiredInterfaces(string $pluginClass): Capable
+    public function testPluginImplementsRequiredInterfaces(string $pluginClass)
     {
         $implements = class_implements($pluginClass);
 
@@ -114,12 +117,18 @@ class PluginTest extends TestCase
      * @uses \CycloneDX\Composer\Factories\ComponentFactory
      * @uses \CycloneDX\Core\Factories\LicenseFactory
      * @uses \CycloneDX\Core\Spdx\License
+     * @uses \CycloneDX\Core\Models\Tool
+     * @uses \CycloneDX\Composer\ToolUpdater
      */
     public function testMakeBomCommandIsRegistered(CommandProvider $commandProvider): void
     {
         $commands = $commandProvider->getCommands();
 
+        self::assertContainsOnlyInstancesOf(\Composer\Command\BaseCommand::class, $commands);
+
         self::assertCount(1, $commands);
-        self::assertContainsOnlyInstancesOf(Command::class, $commands);
+        $command = reset($commands);
+        self::assertInstanceOf(Command::class, $command);
+        self::assertSame('make-bom', $command->getName());
     }
 }

--- a/tests/Composer/ToolUpdaterTest.php
+++ b/tests/Composer/ToolUpdaterTest.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of CycloneDX PHP Composer Plugin.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+
+namespace CycloneDX\Tests\Composer;
+
+use Composer\Package\PackageInterface;
+use Composer\Repository\LockArrayRepository;
+use Composer\Semver\Constraint\MatchAllConstraint;
+use CycloneDX\Composer\Factories\ComponentFactory;
+use CycloneDX\Composer\ToolUpdater;
+use CycloneDX\Core\Models\Component;
+use CycloneDX\Core\Models\Tool;
+use CycloneDX\Core\Repositories\HashRepository;
+use PHPUnit\Framework\Constraint\IsInstanceOf;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \CycloneDX\Composer\ToolUpdater
+ */
+class ToolUpdaterTest extends TestCase
+{
+    public function testUpdateTool(): void
+    {
+        $componentFactory = $this->createMock(ComponentFactory::class);
+        $updater = new ToolUpdater($componentFactory);
+        $tool = $this->createConfiguredMock(
+            Tool::class,
+            [
+                'getVendor' => 'myVendor',
+                'getName' => 'myName',
+            ]
+        );
+        $lockRepo = $this->createMock(LockArrayRepository::class);
+        $hashes = $this->createStub(HashRepository::class);
+        $package = $this->createStub(PackageInterface::class);
+        $component = $this->createConfiguredMock(
+            Component::class,
+            [
+                'getVersion' => 'myVersion',
+                'getHashRepository' => $hashes,
+            ]
+        );
+
+        $lockRepo->method('findPackage')
+            ->with('myVendor/myName', new IsInstanceOf(MatchAllConstraint::class))
+            ->willReturn($package);
+
+        $componentFactory->method('makeFromPackage')
+            ->with($package)
+            ->willReturn($component);
+
+        $tool->expects(self::once())
+            ->method('setVersion')
+            ->with('myVersion');
+
+        $tool->expects(self::once())
+            ->method('setHashRepository')
+            ->with($hashes);
+
+        $updated = $updater->updateTool($tool, $lockRepo);
+
+        self::assertTrue($updated);
+    }
+
+    public function testUpdateToolWithputNameAndVendor(): void
+    {
+        $componentFactory = $this->createMock(ComponentFactory::class);
+        $updater = new ToolUpdater($componentFactory);
+        $tool = $this->createMock(Tool::class);
+        $lockRepo = $this->createStub(LockArrayRepository::class);
+
+        $tool->expects(self::never())
+            ->method('setVersion');
+
+        $tool->expects(self::never())
+            ->method('setHashRepository');
+
+        $updated = $updater->updateTool($tool, $lockRepo);
+
+        self::assertFalse($updated);
+    }
+
+    public function testUpdateToolThatIsUnknown(): void
+    {
+        $componentFactory = $this->createMock(ComponentFactory::class);
+        $updater = new ToolUpdater($componentFactory);
+        $tool = $this->createConfiguredMock(
+            Tool::class,
+            [
+                'getVendor' => 'myVendor',
+                'getName' => 'myName',
+            ]
+        );
+        $lockRepo = $this->createMock(LockArrayRepository::class);
+
+        $lockRepo->method('findPackage')
+            ->with('myVendor/myName', new IsInstanceOf(MatchAllConstraint::class))
+            ->willReturn(null);
+
+        $tool->expects(self::never())
+            ->method('setVersion');
+
+        $tool->expects(self::never())
+            ->method('setHashRepository');
+
+        $updated = $updater->updateTool($tool, $lockRepo);
+
+        self::assertFalse($updated);
+    }
+
+    public function testUpdateToolThatDoesNotConvertToComponent(): void
+    {
+        $componentFactory = $this->createMock(ComponentFactory::class);
+        $updater = new ToolUpdater($componentFactory);
+        $tool = $this->createConfiguredMock(
+            Tool::class,
+            [
+                'getVendor' => 'myVendor',
+                'getName' => 'myName',
+            ]
+        );
+        $lockRepo = $this->createMock(LockArrayRepository::class);
+        $package = $this->createStub(PackageInterface::class);
+
+        $lockRepo->method('findPackage')
+            ->with('myVendor/myName', new IsInstanceOf(MatchAllConstraint::class))
+            ->willReturn($package);
+
+        $componentFactory->method('makeFromPackage')
+            ->with($package)
+            ->willThrowException(new \Exception());
+
+        $tool->expects(self::never())
+            ->method('setVersion');
+
+        $tool->expects(self::never())
+            ->method('setHashRepository');
+
+        $updated = $updater->updateTool($tool, $lockRepo);
+
+        self::assertFalse($updated);
+    }
+}

--- a/tests/Core/Models/BomTest.php
+++ b/tests/Core/Models/BomTest.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace CycloneDX\Tests\Core\Models;
 
 use CycloneDX\Core\Models\Bom;
+use CycloneDX\Core\Models\MetaData;
 use CycloneDX\Core\Repositories\ComponentRepository;
 use PHPUnit\Framework\TestCase;
 
@@ -72,4 +73,15 @@ class BomTest extends TestCase
     }
 
     // endregion version setter&getter
+
+    // region metaData setter&getter
+
+    public function testMetaDataSetterGetter(): void
+    {
+        $metaData = $this->createStub(MetaData::class);
+        $this->bom->setMetaData($metaData);
+        self::assertSame($metaData, $this->bom->getMetaData());
+    }
+
+    // endregion metaData setter&getter
 }

--- a/tests/Core/Models/MetaDataTest.php
+++ b/tests/Core/Models/MetaDataTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of CycloneDX PHP Composer Plugin.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+
+namespace CycloneDX\Tests\Core\Models;
+
+use CycloneDX\Core\Models\Component;
+use CycloneDX\Core\Models\MetaData;
+use CycloneDX\Core\Repositories\ToolRepository;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \CycloneDX\Core\Models\MetaData
+ */
+class MetaDataTest extends TestCase
+{
+    public function testConstructor(): MetaData
+    {
+        $metaData = new MetaData();
+
+        self::assertNull($metaData->getTools());
+        self::assertNull($metaData->getComponent());
+
+        return $metaData;
+    }
+
+    /**
+     * @depends testConstructor
+     */
+    public function testGetterSetterTools(MetaData $metaData): void
+    {
+        $tools = $this->createStub(ToolRepository::class);
+        $metaData->setTools($tools);
+        self::assertSame($tools, $metaData->getTools());
+    }
+
+    /**
+     * @depends testConstructor
+     */
+    public function testSetterSetterComponent(MetaData $metaData): void
+    {
+        $component = $this->createStub(Component::class);
+        $metaData->setComponent($component);
+        self::assertSame($component, $metaData->getComponent());
+    }
+}

--- a/tests/Core/Models/ToolTest.php
+++ b/tests/Core/Models/ToolTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of CycloneDX PHP Composer Plugin.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+
+namespace CycloneDX\Tests\Core\Models;
+
+use CycloneDX\Core\Models\Tool;
+use CycloneDX\Core\Repositories\HashRepository;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \CycloneDX\Core\Models\Tool
+ */
+class ToolTest extends TestCase
+{
+    public function testConstruct(): Tool
+    {
+        $tool = new Tool();
+
+        self::assertNull($tool->getVendor());
+        self::assertNull($tool->getName());
+        self::assertNull($tool->getVersion());
+        self::assertNull($tool->getHashRepository());
+
+        return $tool;
+    }
+
+    /**
+     * @depends testConstruct
+     */
+    public function testSetterGetterVersion(Tool $tool): void
+    {
+        $version = 'v1.2.3';
+        $tool->setVersion($version);
+        self::assertSame($version, $tool->getVersion());
+    }
+
+    /**
+     * @depends testConstruct
+     */
+    public function testSetterGetterVendor(Tool $tool): void
+    {
+        $vendor = 'myVendor';
+        $tool->setVendor($vendor);
+        self::assertSame($vendor, $tool->getVendor());
+    }
+
+    /**
+     * @depends testConstruct
+     */
+    public function testSetterGetterName(Tool $tool): void
+    {
+        $name = 'myName';
+        $tool->setName($name);
+        self::assertSame($name, $tool->getName());
+    }
+
+    /**
+     * @depends testConstruct
+     */
+    public function testSetterGetterHashRepository(Tool $tool): void
+    {
+        $hashes = $this->createStub(HashRepository::class);
+        $tool->setHashRepository($hashes);
+        self::assertSame($hashes, $tool->getHashRepository());
+    }
+}

--- a/tests/Core/Repositories/ToolRepositoryTest.php
+++ b/tests/Core/Repositories/ToolRepositoryTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of CycloneDX PHP Composer Plugin.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+
+namespace CycloneDX\Tests\Core\Repositories;
+
+use CycloneDX\Core\Models\Tool;
+use CycloneDX\Core\Repositories\ToolRepository;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \CycloneDX\Core\Repositories\ToolRepository
+ */
+class ToolRepositoryTest extends TestCase
+{
+    public function testAddAndGetTool(): void
+    {
+        $tool1 = $this->createStub(Tool::class);
+        $tool2 = $this->createStub(Tool::class);
+        $tool3 = $this->createStub(Tool::class);
+
+        $repo = new ToolRepository($tool1);
+        $repo->addTool($tool2, $tool3);
+        $got = $repo->getTools();
+
+        self::assertCount(3, $got);
+        self::assertContains($tool1, $got);
+        self::assertContains($tool2, $got);
+        self::assertContains($tool3, $got);
+    }
+
+    public function testCount(): void
+    {
+        $tool1 = $this->createStub(Tool::class);
+        $tool2 = $this->createStub(Tool::class);
+
+        $repo = new ToolRepository($tool1);
+        $repo->addTool($tool2);
+
+        self::assertSame(2, $repo->count());
+    }
+
+    public function testConstructAndGet(): void
+    {
+        $tool1 = $this->createStub(Tool::class);
+        $tool2 = $this->createStub(Tool::class);
+
+        $repo = new ToolRepository($tool1, $tool2);
+        $got = $repo->getTools();
+
+        self::assertCount(2, $got);
+        self::assertContains($tool1, $got);
+        self::assertContains($tool2, $got);
+    }
+}

--- a/tests/Core/ResourcesTest.php
+++ b/tests/Core/ResourcesTest.php
@@ -27,7 +27,7 @@ use CycloneDX\Core\Resources;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @covers \CycloneDX\Core\Resources
+ * @coversNothing
  */
 class ResourcesTest extends TestCase
 {

--- a/tests/Core/Serialize/DOM/NormalizerFactoryTest.php
+++ b/tests/Core/Serialize/DOM/NormalizerFactoryTest.php
@@ -24,14 +24,7 @@ declare(strict_types=1);
 namespace CycloneDX\Tests\Core\Serialize\DOM;
 
 use CycloneDX\Core\Serialize\DOM\NormalizerFactory;
-use CycloneDX\Core\Serialize\DOM\Normalizers\BomNormalizer;
-use CycloneDX\Core\Serialize\DOM\Normalizers\ComponentNormalizer;
-use CycloneDX\Core\Serialize\DOM\Normalizers\ComponentRepositoryNormalizer;
-use CycloneDX\Core\Serialize\DOM\Normalizers\DisjunctiveLicenseNormalizer;
-use CycloneDX\Core\Serialize\DOM\Normalizers\DisjunctiveLicenseRepositoryNormalizer;
-use CycloneDX\Core\Serialize\DOM\Normalizers\HashNormalizer;
-use CycloneDX\Core\Serialize\DOM\Normalizers\HashRepositoryNormalizer;
-use CycloneDX\Core\Serialize\DOM\Normalizers\LicenseExpressionNormalizer;
+use CycloneDX\Core\Serialize\DOM\Normalizers;
 use CycloneDX\Core\Spec\SpecInterface;
 use DomainException;
 use PHPUnit\Framework\TestCase;
@@ -122,7 +115,7 @@ class NormalizerFactoryTest extends TestCase
     public function testMakeForComponentRepository(NormalizerFactory $factory): void
     {
         $got = $factory->makeForComponentRepository();
-        self::assertInstanceOf(ComponentRepositoryNormalizer::class, $got);
+        self::assertInstanceOf(Normalizers\ComponentRepositoryNormalizer::class, $got);
         self::assertSame($factory, $got->getNormalizerFactory());
     }
 
@@ -134,7 +127,7 @@ class NormalizerFactoryTest extends TestCase
     public function testMakeForBom(NormalizerFactory $factory): void
     {
         $got = $factory->makeForBom();
-        self::assertInstanceOf(BomNormalizer::class, $got);
+        self::assertInstanceOf(Normalizers\BomNormalizer::class, $got);
         self::assertSame($factory, $got->getNormalizerFactory());
     }
 
@@ -146,7 +139,7 @@ class NormalizerFactoryTest extends TestCase
     public function testMakeForDisjunctiveLicense(NormalizerFactory $factory): void
     {
         $got = $factory->makeForDisjunctiveLicense();
-        self::assertInstanceOf(DisjunctiveLicenseNormalizer::class, $got);
+        self::assertInstanceOf(Normalizers\DisjunctiveLicenseNormalizer::class, $got);
         self::assertSame($factory, $got->getNormalizerFactory());
     }
 
@@ -158,7 +151,7 @@ class NormalizerFactoryTest extends TestCase
     public function testMakeForHashRepository(NormalizerFactory $factory): void
     {
         $got = $factory->makeForHashRepository();
-        self::assertInstanceOf(HashRepositoryNormalizer::class, $got);
+        self::assertInstanceOf(Normalizers\HashRepositoryNormalizer::class, $got);
         self::assertSame($factory, $got->getNormalizerFactory());
     }
 
@@ -170,7 +163,7 @@ class NormalizerFactoryTest extends TestCase
     public function testMakeForComponent(NormalizerFactory $factory): void
     {
         $got = $factory->makeForComponent();
-        self::assertInstanceOf(ComponentNormalizer::class, $got);
+        self::assertInstanceOf(Normalizers\ComponentNormalizer::class, $got);
         self::assertSame($factory, $got->getNormalizerFactory());
     }
 
@@ -182,7 +175,7 @@ class NormalizerFactoryTest extends TestCase
     public function testMakeForDisjunctiveLicenseRepository(NormalizerFactory $factory): void
     {
         $got = $factory->makeForDisjunctiveLicenseRepository();
-        self::assertInstanceOf(DisjunctiveLicenseRepositoryNormalizer::class, $got);
+        self::assertInstanceOf(Normalizers\DisjunctiveLicenseRepositoryNormalizer::class, $got);
         self::assertSame($factory, $got->getNormalizerFactory());
     }
 
@@ -194,7 +187,7 @@ class NormalizerFactoryTest extends TestCase
     public function testMakeForLicenseExpression(NormalizerFactory $factory): void
     {
         $got = $factory->makeForLicenseExpression();
-        self::assertInstanceOf(LicenseExpressionNormalizer::class, $got);
+        self::assertInstanceOf(Normalizers\LicenseExpressionNormalizer::class, $got);
         self::assertSame($factory, $got->getNormalizerFactory());
     }
 
@@ -206,7 +199,43 @@ class NormalizerFactoryTest extends TestCase
     public function testMakeForHash(NormalizerFactory $factory): void
     {
         $got = $factory->makeForHash();
-        self::assertInstanceOf(HashNormalizer::class, $got);
+        self::assertInstanceOf(Normalizers\HashNormalizer::class, $got);
+        self::assertSame($factory, $got->getNormalizerFactory());
+    }
+
+    /**
+     * @depends testConstructor
+     *
+     * @uses \CycloneDX\Core\Serialize\DOM\Normalizers\MetaDataNormalizer
+     */
+    public function testMakeForMetaData(NormalizerFactory $factory): void
+    {
+        $got = $factory->makeForMetaData();
+        self::assertInstanceOf(Normalizers\MetaDataNormalizer::class, $got);
+        self::assertSame($factory, $got->getNormalizerFactory());
+    }
+
+    /**
+     * @depends testConstructor
+     *
+     * @uses \CycloneDX\Core\Serialize\DOM\Normalizers\ToolRepositoryNormalizer
+     */
+    public function testMakeForToolRepository(NormalizerFactory $factory): void
+    {
+        $got = $factory->makeForToolRepository();
+        self::assertInstanceOf(Normalizers\ToolRepositoryNormalizer::class, $got);
+        self::assertSame($factory, $got->getNormalizerFactory());
+    }
+
+    /**
+     * @depends testConstructor
+     *
+     * @uses \CycloneDX\Core\Serialize\DOM\Normalizers\ToolNormalizer
+     */
+    public function testMakeForTool(NormalizerFactory $factory): void
+    {
+        $got = $factory->makeForTool();
+        self::assertInstanceOf(Normalizers\ToolNormalizer::class, $got);
         self::assertSame($factory, $got->getNormalizerFactory());
     }
 }

--- a/tests/Core/Serialize/DOM/Normalizers/ComponentRepositoryNormalizerTest.php
+++ b/tests/Core/Serialize/DOM/Normalizers/ComponentRepositoryNormalizerTest.php
@@ -75,4 +75,29 @@ class ComponentRepositoryNormalizerTest extends TestCase
 
         self::assertSame([$FakeComponent], $got);
     }
+
+    public function testNormalizeSkipsOnThrow(): void
+    {
+        $spec = $this->createStub(SpecInterface::class);
+        $componentNormalizer = $this->createMock(ComponentNormalizer::class);
+        $factory = $this->createConfiguredMock(NormalizerFactory::class, [
+            'getSpec' => $spec,
+            'makeForComponent' => $componentNormalizer,
+        ]);
+        $normalizer = new ComponentRepositoryNormalizer($factory);
+        $component1 = $this->createStub(Component::class);
+        $component2 = $this->createStub(Component::class);
+        $components = $this->createConfiguredMock(ComponentRepository::class, [
+            'count' => 1,
+            'getComponents' => [$component1, $component2],
+        ]);
+
+        $componentNormalizer->expects(self::exactly(2))->method('normalize')
+            ->withConsecutive([$component1], [$component2])
+            ->willThrowException(new \DomainException());
+
+        $got = $normalizer->normalize($components);
+
+        self::assertSame([], $got);
+    }
 }

--- a/tests/Core/Serialize/DOM/Normalizers/DisjunctiveLicenseRepositoryNormalizerTest.php
+++ b/tests/Core/Serialize/DOM/Normalizers/DisjunctiveLicenseRepositoryNormalizerTest.php
@@ -62,7 +62,7 @@ class DisjunctiveLicenseRepositoryNormalizerTest extends TestCase
         self::assertSame([$dummy1, $dummy2], $normalized);
     }
 
-    public function testNormalizeThrows(): void
+    public function testNormalizeSkipsOnThrows(): void
     {
         $license1 = $this->createStub(DisjunctiveLicenseWithId::class);
         $license2 = $this->createStub(DisjunctiveLicenseWithName::class);
@@ -72,13 +72,12 @@ class DisjunctiveLicenseRepositoryNormalizerTest extends TestCase
         $repo = $this->createStub(DisjunctiveLicenseRepository::class);
         $repo->method('getLicenses')->willReturn([$license1, $license2]);
 
-        $licenseNormalizer->expects(self::once())->method('normalize')
-            ->with($license1)
+        $licenseNormalizer->expects(self::exactly(2))->method('normalize')
+            ->withConsecutive([$license1], [$license2])
             ->willThrowException(new \InvalidArgumentException());
 
-        $this->expectException(\DomainException::class);
-        $this->expectExceptionMessageMatches('/unsupported license/i');
+        $got = $normalizer->normalize($repo);
 
-        $normalizer->normalize($repo);
+        self::assertSame([], $got);
     }
 }

--- a/tests/Core/Serialize/DOM/Normalizers/MetaDataNormalizerTest.php
+++ b/tests/Core/Serialize/DOM/Normalizers/MetaDataNormalizerTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of CycloneDX PHP Composer Plugin.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+
+namespace CycloneDX\Tests\Core\Serialize\DOM\Normalizers;
+
+use CycloneDX\Core\Models\Component;
+use CycloneDX\Core\Models\MetaData;
+use CycloneDX\Core\Repositories\ToolRepository;
+use CycloneDX\Core\Serialize\DOM\NormalizerFactory;
+use CycloneDX\Core\Serialize\DOM\Normalizers\ComponentNormalizer;
+use CycloneDX\Core\Serialize\DOM\Normalizers\MetaDataNormalizer;
+use CycloneDX\Core\Serialize\DOM\Normalizers\ToolRepositoryNormalizer;
+use CycloneDX\Core\Spec\SpecInterface;
+use CycloneDX\Tests\_traits\DomNodeAssertionTrait;
+use DOMDocument;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \CycloneDX\Core\Serialize\DOM\Normalizers\MetaDataNormalizer
+ * @covers \CycloneDX\Core\Serialize\DOM\AbstractNormalizer
+ */
+class MetaDataNormalizerTest extends TestCase
+{
+    use DomNodeAssertionTrait;
+
+    public function testNormalizeEmpty(): void
+    {
+        $metaData = $this->createMock(MetaData::class);
+        $spec = $this->createMock(SpecInterface::class);
+        $factory = $this->createConfiguredMock(
+            NormalizerFactory::class,
+            ['getSpec' => $spec, 'getDocument' => new DOMDocument()]
+        );
+        $normalizer = new MetaDataNormalizer($factory);
+
+        $actual = $normalizer->normalize($metaData);
+
+        self::assertStringEqualsDomNode('<metadata></metadata>', $actual);
+    }
+
+    public function testNormalizeTools(): void
+    {
+        $metaData = $this->createConfiguredMock(
+            MetaData::class,
+            [
+                'getTools' => $this->createConfiguredMock(ToolRepository::class, ['count' => 2]),
+            ]
+        );
+        $spec = $this->createMock(SpecInterface::class);
+        $toolsRepoFactory = $this->createMock(ToolRepositoryNormalizer::class);
+        $factory = $this->createConfiguredMock(
+            NormalizerFactory::class,
+            [
+                'getSpec' => $spec,
+                'getDocument' => new DOMDocument(),
+                'makeForToolRepository' => $toolsRepoFactory,
+            ]
+        );
+        $normalizer = new MetaDataNormalizer($factory);
+
+        $toolsRepoFactory->expects(self::once())
+            ->method('normalize')
+            ->with($metaData->getTools())
+            ->willReturn([$factory->getDocument()->createElement('FakeTool', 'dummy')]);
+
+        $actual = $normalizer->normalize($metaData);
+
+        self::assertStringEqualsDomNode(
+            '<metadata><tools><FakeTool>dummy</FakeTool></tools></metadata>',
+            $actual
+        );
+    }
+
+    public function testNormalizeComponent(): void
+    {
+        $metaData = $this->createConfiguredMock(
+            MetaData::class,
+            [
+                'getComponent' => $this->createMock(Component::class),
+            ]
+        );
+        $spec = $this->createMock(SpecInterface::class);
+        $componentFactory = $this->createMock(ComponentNormalizer::class);
+        $factory = $this->createConfiguredMock(
+            NormalizerFactory::class,
+            [
+                'getSpec' => $spec,
+                'getDocument' => new DOMDocument(),
+                'makeForComponent' => $componentFactory,
+            ]
+        );
+        $normalizer = new MetaDataNormalizer($factory);
+
+        $componentFactory->expects(self::once())
+            ->method('normalize')
+            ->with($metaData->getComponent())
+            ->willReturn($factory->getDocument()->createElement('FakeComponent', 'dummy'));
+
+        $actual = $normalizer->normalize($metaData);
+
+        self::assertStringEqualsDomNode(
+            '<metadata><FakeComponent>dummy</FakeComponent></metadata>',
+            $actual
+        );
+    }
+
+    public function testNormalizeComponentUnsupported(): void
+    {
+        $metaData = $this->createConfiguredMock(
+            MetaData::class,
+            [
+                'getComponent' => $this->createMock(Component::class),
+            ]
+        );
+        $spec = $this->createMock(SpecInterface::class);
+        $componentFactory = $this->createMock(ComponentNormalizer::class);
+        $factory = $this->createConfiguredMock(
+            NormalizerFactory::class,
+            [
+                'getSpec' => $spec,
+                'getDocument' => new DOMDocument(),
+                'makeForComponent' => $componentFactory,
+            ]
+        );
+        $normalizer = new MetaDataNormalizer($factory);
+
+        $componentFactory->expects(self::once())
+            ->method('normalize')
+            ->with($metaData->getComponent())
+            ->willThrowException(new \DomainException());
+
+        $actual = $normalizer->normalize($metaData);
+
+        self::assertStringEqualsDomNode(
+            '<metadata></metadata>',
+            $actual
+        );
+    }
+}

--- a/tests/Core/Serialize/DOM/Normalizers/ToolNormalizerTest.php
+++ b/tests/Core/Serialize/DOM/Normalizers/ToolNormalizerTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of CycloneDX PHP Composer Plugin.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+
+namespace CycloneDX\Tests\Core\Serialize\DOM\Normalizers;
+
+use CycloneDX\Core\Models\Tool;
+use CycloneDX\Core\Repositories\HashRepository;
+use CycloneDX\Core\Serialize\DOM\NormalizerFactory;
+use CycloneDX\Core\Serialize\DOM\Normalizers\HashRepositoryNormalizer;
+use CycloneDX\Core\Serialize\DOM\Normalizers\ToolNormalizer;
+use CycloneDX\Core\Spec\SpecInterface;
+use CycloneDX\Tests\_traits\DomNodeAssertionTrait;
+use DOMDocument;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \CycloneDX\Core\Serialize\DOM\Normalizers\ToolNormalizer
+ *
+ * @uses   \CycloneDX\Core\Serialize\DOM\AbstractNormalizer
+ */
+class ToolNormalizerTest extends TestCase
+{
+    use DomNodeAssertionTrait;
+
+    public function testNormalizeEmpty(): void
+    {
+        $tool = $this->createMock(Tool::class);
+        $spec = $this->createMock(SpecInterface::class);
+        $factory = $this->createConfiguredMock(
+            NormalizerFactory::class,
+            [
+                'getSpec' => $spec,
+                'getDocument' => new DOMDocument(),
+            ]
+        );
+        $normalizer = new ToolNormalizer($factory);
+
+        $actual = $normalizer->normalize($tool);
+
+        self::assertStringEqualsDomNode(
+            '<tool></tool>',
+            $actual
+        );
+    }
+
+    /**
+     * @uses \CycloneDX\Core\Serialize\DOM\Normalizers\HashRepositoryNormalizer
+     */
+    public function testNormalize(): void
+    {
+        $tool = $this->createConfiguredMock(
+            Tool::class,
+            [
+                'getVendor' => 'myVendor',
+                'getName' => 'myName',
+                'getVersion' => 'myVersion',
+                'getHashRepository' => $this->createConfiguredMock(HashRepository::class, ['count' => 2]),
+            ]
+        );
+        $spec = $this->createMock(SpecInterface::class);
+        $hashRepoNormalizer = $this->createMock(HashRepositoryNormalizer::class, );
+        $factory = $this->createConfiguredMock(
+            NormalizerFactory::class,
+            [
+                'getSpec' => $spec,
+                'getDocument' => new DOMDocument(),
+                'makeForHashRepository' => $hashRepoNormalizer,
+            ]
+        );
+        $normalizer = new ToolNormalizer($factory);
+
+        $hashRepoNormalizer->expects(self::once())
+            ->method('normalize')
+            ->with($tool->getHashRepository())
+            ->willReturn([$factory->getDocument()->createElement('FakeHash', 'dummy')]);
+
+        $actual = $normalizer->normalize($tool);
+
+        self::assertStringEqualsDomNode(
+            '<tool>'.
+            '<vendor>myVendor</vendor>'.
+            '<name>myName</name>'.
+            '<version>myVersion</version>'.
+            '<hashes><FakeHash>dummy</FakeHash></hashes>'.
+            '</tool>',
+            $actual
+        );
+    }
+}

--- a/tests/Core/Serialize/DOM/Normalizers/ToolRepositoryNormalizerTest.php
+++ b/tests/Core/Serialize/DOM/Normalizers/ToolRepositoryNormalizerTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of CycloneDX PHP Composer Plugin.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+
+namespace CycloneDX\Tests\Core\Serialize\DOM\Normalizers;
+
+use CycloneDX\Core\Models\Tool;
+use CycloneDX\Core\Repositories\ToolRepository;
+use CycloneDX\Core\Serialize\DOM\NormalizerFactory;
+use CycloneDX\Core\Serialize\DOM\Normalizers\ToolNormalizer;
+use CycloneDX\Core\Serialize\DOM\Normalizers\ToolRepositoryNormalizer;
+use CycloneDX\Core\Spec\SpecInterface;
+use DOMElement;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \CycloneDX\Core\Serialize\DOM\Normalizers\ToolRepositoryNormalizer
+ * @covers \CycloneDX\Core\Serialize\DOM\AbstractNormalizer
+ * @covers \CycloneDX\Core\Helpers\SimpleDomTrait
+ */
+class ToolRepositoryNormalizerTest extends TestCase
+{
+    public function testNormalizeEmpty(): void
+    {
+        $spec = $this->createStub(SpecInterface::class);
+        $factory = $this->createConfiguredMock(NormalizerFactory::class, ['getSpec' => $spec]);
+        $normalizer = new ToolRepositoryNormalizer($factory);
+        $tools = $this->createConfiguredMock(ToolRepository::class, ['count' => 0]);
+
+        $actual = $normalizer->normalize($tools);
+
+        self::assertSame([], $actual);
+    }
+
+    public function testNormalize(): void
+    {
+        $spec = $this->createStub(SpecInterface::class);
+        $toolNormalizer = $this->createMock(ToolNormalizer::class);
+        $factory = $this->createConfiguredMock(NormalizerFactory::class, [
+            'getSpec' => $spec,
+            'makeForTool' => $toolNormalizer,
+        ]);
+        $normalizer = new ToolRepositoryNormalizer($factory);
+        $tool = $this->createStub(Tool::class);
+        $tools = $this->createConfiguredMock(ToolRepository::class, [
+            'count' => 1,
+            'getTools' => [$tool],
+        ]);
+        $FakeTool = $this->createStub(DOMElement::class);
+
+        $toolNormalizer->expects(self::once())->method('normalize')
+            ->with($tool)
+            ->willReturn($FakeTool);
+
+        $actual = $normalizer->normalize($tools);
+
+        self::assertSame([$FakeTool], $actual);
+    }
+
+    public function testNormalizeSkipsOnThrow(): void
+    {
+        $spec = $this->createStub(SpecInterface::class);
+        $toolNormalizer = $this->createMock(ToolNormalizer::class);
+        $factory = $this->createConfiguredMock(NormalizerFactory::class, [
+            'getSpec' => $spec,
+            'makeForTool' => $toolNormalizer,
+        ]);
+        $normalizer = new ToolRepositoryNormalizer($factory);
+        $tool1 = $this->createStub(Tool::class);
+        $tool2 = $this->createStub(Tool::class);
+        $tools = $this->createConfiguredMock(ToolRepository::class, [
+            'count' => 1,
+            'getTools' => [$tool1, $tool2],
+        ]);
+
+        $toolNormalizer->expects(self::exactly(2))->method('normalize')
+            ->withConsecutive([$tool1], [$tool2])
+            ->willThrowException(new \DomainException());
+
+        $actual = $normalizer->normalize($tools);
+
+        self::assertSame([], $actual);
+    }
+}

--- a/tests/Core/Serialize/JSON/NormalizerFactoryTest.php
+++ b/tests/Core/Serialize/JSON/NormalizerFactoryTest.php
@@ -24,14 +24,7 @@ declare(strict_types=1);
 namespace CycloneDX\Tests\Core\Serialize\JSON;
 
 use CycloneDX\Core\Serialize\JSON\NormalizerFactory;
-use CycloneDX\Core\Serialize\JSON\Normalizers\BomNormalizer;
-use CycloneDX\Core\Serialize\JSON\Normalizers\ComponentNormalizer;
-use CycloneDX\Core\Serialize\JSON\Normalizers\ComponentRepositoryNormalizer;
-use CycloneDX\Core\Serialize\JSON\Normalizers\DisjunctiveLicenseNormalizer;
-use CycloneDX\Core\Serialize\JSON\Normalizers\DisjunctiveLicenseRepositoryNormalizer;
-use CycloneDX\Core\Serialize\JSON\Normalizers\HashNormalizer;
-use CycloneDX\Core\Serialize\JSON\Normalizers\HashRepositoryNormalizer;
-use CycloneDX\Core\Serialize\JSON\Normalizers\LicenseExpressionNormalizer;
+use CycloneDX\Core\Serialize\JSON\Normalizers;
 use CycloneDX\Core\Spec\SpecInterface;
 use DomainException;
 use PHPUnit\Framework\TestCase;
@@ -121,7 +114,7 @@ class NormalizerFactoryTest extends TestCase
     public function testMakeForComponentRepository(NormalizerFactory $factory): void
     {
         $got = $factory->makeForComponentRepository();
-        self::assertInstanceOf(ComponentRepositoryNormalizer::class, $got);
+        self::assertInstanceOf(Normalizers\ComponentRepositoryNormalizer::class, $got);
         self::assertSame($factory, $got->getNormalizerFactory());
     }
 
@@ -133,7 +126,7 @@ class NormalizerFactoryTest extends TestCase
     public function testMakeForBom(NormalizerFactory $factory): void
     {
         $got = $factory->makeForBom();
-        self::assertInstanceOf(BomNormalizer::class, $got);
+        self::assertInstanceOf(Normalizers\BomNormalizer::class, $got);
         self::assertSame($factory, $got->getNormalizerFactory());
     }
 
@@ -145,7 +138,7 @@ class NormalizerFactoryTest extends TestCase
     public function testMakeForDisjunctiveLicense(NormalizerFactory $factory): void
     {
         $got = $factory->makeForDisjunctiveLicense();
-        self::assertInstanceOf(DisjunctiveLicenseNormalizer::class, $got);
+        self::assertInstanceOf(Normalizers\DisjunctiveLicenseNormalizer::class, $got);
         self::assertSame($factory, $got->getNormalizerFactory());
     }
 
@@ -157,7 +150,7 @@ class NormalizerFactoryTest extends TestCase
     public function testMakeForHashRepository(NormalizerFactory $factory): void
     {
         $got = $factory->makeForHashRepository();
-        self::assertInstanceOf(HashRepositoryNormalizer::class, $got);
+        self::assertInstanceOf(Normalizers\HashRepositoryNormalizer::class, $got);
         self::assertSame($factory, $got->getNormalizerFactory());
     }
 
@@ -169,7 +162,7 @@ class NormalizerFactoryTest extends TestCase
     public function testMakeForComponent(NormalizerFactory $factory): void
     {
         $got = $factory->makeForComponent();
-        self::assertInstanceOf(ComponentNormalizer::class, $got);
+        self::assertInstanceOf(Normalizers\ComponentNormalizer::class, $got);
         self::assertSame($factory, $got->getNormalizerFactory());
     }
 
@@ -181,7 +174,7 @@ class NormalizerFactoryTest extends TestCase
     public function testMakeForDisjunctiveLicenseRepository(NormalizerFactory $factory): void
     {
         $got = $factory->makeForDisjunctiveLicenseRepository();
-        self::assertInstanceOf(DisjunctiveLicenseRepositoryNormalizer::class, $got);
+        self::assertInstanceOf(Normalizers\DisjunctiveLicenseRepositoryNormalizer::class, $got);
         self::assertSame($factory, $got->getNormalizerFactory());
     }
 
@@ -193,7 +186,7 @@ class NormalizerFactoryTest extends TestCase
     public function testMakeForLicenseExpression(NormalizerFactory $factory): void
     {
         $got = $factory->makeForLicenseExpression();
-        self::assertInstanceOf(LicenseExpressionNormalizer::class, $got);
+        self::assertInstanceOf(Normalizers\LicenseExpressionNormalizer::class, $got);
         self::assertSame($factory, $got->getNormalizerFactory());
     }
 
@@ -205,7 +198,43 @@ class NormalizerFactoryTest extends TestCase
     public function testMakeForHash(NormalizerFactory $factory): void
     {
         $got = $factory->makeForHash();
-        self::assertInstanceOf(HashNormalizer::class, $got);
+        self::assertInstanceOf(Normalizers\HashNormalizer::class, $got);
+        self::assertSame($factory, $got->getNormalizerFactory());
+    }
+
+    /**
+     * @depends testConstructor
+     *
+     * @uses \CycloneDX\Core\Serialize\JSON\Normalizers\MetaDataNormalizer
+     */
+    public function testMakeForMetaData(NormalizerFactory $factory): void
+    {
+        $got = $factory->makeForMetaData();
+        self::assertInstanceOf(Normalizers\MetaDataNormalizer::class, $got);
+        self::assertSame($factory, $got->getNormalizerFactory());
+    }
+
+    /**
+     * @depends testConstructor
+     *
+     * @uses \CycloneDX\Core\Serialize\JSON\Normalizers\ToolRepositoryNormalizer
+     */
+    public function testMakeForToolRepository(NormalizerFactory $factory): void
+    {
+        $got = $factory->makeForToolRepository();
+        self::assertInstanceOf(Normalizers\ToolRepositoryNormalizer::class, $got);
+        self::assertSame($factory, $got->getNormalizerFactory());
+    }
+
+    /**
+     * @depends testConstructor
+     *
+     * @uses \CycloneDX\Core\Serialize\JSON\Normalizers\ToolNormalizer
+     */
+    public function testMakeForTool(NormalizerFactory $factory): void
+    {
+        $got = $factory->makeForTool();
+        self::assertInstanceOf(Normalizers\ToolNormalizer::class, $got);
         self::assertSame($factory, $got->getNormalizerFactory());
     }
 }

--- a/tests/Core/Serialize/JSON/Normalizers/ComponentRepositoryNormalizerTest.php
+++ b/tests/Core/Serialize/JSON/Normalizers/ComponentRepositoryNormalizerTest.php
@@ -72,4 +72,29 @@ class ComponentRepositoryNormalizerTest extends TestCase
 
         self::assertSame([['FakeComponent']], $got);
     }
+
+    public function testNormalizeSkipsOnThrow(): void
+    {
+        $spec = $this->createStub(SpecInterface::class);
+        $componentNormalizer = $this->createMock(ComponentNormalizer::class);
+        $factory = $this->createConfiguredMock(NormalizerFactory::class, [
+            'getSpec' => $spec,
+            'makeForComponent' => $componentNormalizer,
+        ]);
+        $normalizer = new ComponentRepositoryNormalizer($factory);
+        $component1 = $this->createStub(Component::class);
+        $component2 = $this->createStub(Component::class);
+        $components = $this->createConfiguredMock(ComponentRepository::class, [
+            'count' => 1,
+            'getComponents' => [$component1, $component2],
+        ]);
+
+        $componentNormalizer->expects(self::exactly(2))->method('normalize')
+            ->withConsecutive([$component1], [$component2])
+            ->willThrowException(new \DomainException());
+
+        $got = $normalizer->normalize($components);
+
+        self::assertSame([], $got);
+    }
 }

--- a/tests/Core/Serialize/JSON/Normalizers/DisjunctiveLicenseRepositoryNormalizerTest.php
+++ b/tests/Core/Serialize/JSON/Normalizers/DisjunctiveLicenseRepositoryNormalizerTest.php
@@ -59,7 +59,7 @@ class DisjunctiveLicenseRepositoryNormalizerTest extends TestCase
         self::assertSame([['dummy1'], ['dummy2']], $normalized);
     }
 
-    public function testNormalizeThrows(): void
+    public function testNormalizeSkipOnThrows(): void
     {
         $license1 = $this->createStub(DisjunctiveLicenseWithId::class);
         $license2 = $this->createStub(DisjunctiveLicenseWithName::class);
@@ -69,13 +69,12 @@ class DisjunctiveLicenseRepositoryNormalizerTest extends TestCase
         $repo = $this->createStub(DisjunctiveLicenseRepository::class);
         $repo->method('getLicenses')->willReturn([$license1, $license2]);
 
-        $licenseNormalizer->expects(self::once())->method('normalize')
-            ->with($license1)
+        $licenseNormalizer->expects(self::exactly(2))->method('normalize')
+            ->withConsecutive([$license1], [$license2])
             ->willThrowException(new \InvalidArgumentException());
 
-        $this->expectException(\DomainException::class);
-        $this->expectExceptionMessageMatches('/unsupported license/i');
+        $got = $normalizer->normalize($repo);
 
-        $normalizer->normalize($repo);
+        self::assertSame([], $got);
     }
 }

--- a/tests/Core/Serialize/JSON/Normalizers/HashRepositoryNormalizerTest.php
+++ b/tests/Core/Serialize/JSON/Normalizers/HashRepositoryNormalizerTest.php
@@ -63,23 +63,23 @@ class HashRepositoryNormalizerTest extends TestCase
     /**
      * @depends testConstructor
      */
-    public function testNormalizeThrowOnThrow(): void
+    public function testNormalizeSkipOnThrow(): void
     {
         $hashNormalizer = $this->createMock(HashNormalizer::class);
         $factory = $this->createConfiguredMock(NormalizerFactory::class, ['makeForHash' => $hashNormalizer]);
         $normalizer = new HashRepositoryNormalizer($factory);
 
         $repo = $this->createConfiguredMock(HashRepository::class, [
-            'getHashes' => ['alg1' => 'cont1', 'alg2', 'cont2'],
+            'getHashes' => ['alg1' => 'cont1', 'alg2' => 'cont2'],
         ]);
 
-        $exception = new DomainException();
-        $hashNormalizer->expects(self::once())->method('normalize')
-            ->with('alg1', 'cont1')
-            ->willThrowException($exception);
+        $hashNormalizer->expects(self::exactly(2))
+            ->method('normalize')
+            ->withConsecutive(['alg1', 'cont1'], ['alg2', 'cont2'])
+            ->willThrowException(new DomainException());
 
-        $this->expectExceptionObject($exception);
+        $got = $normalizer->normalize($repo);
 
-        $normalizer->normalize($repo);
+        self::assertSame([], $got);
     }
 }

--- a/tests/Core/Serialize/JSON/Normalizers/MetaDataNormalizerTest.php
+++ b/tests/Core/Serialize/JSON/Normalizers/MetaDataNormalizerTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of CycloneDX PHP Composer Plugin.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+
+namespace CycloneDX\Tests\Core\Serialize\JSON\Normalizers;
+
+use CycloneDX\Core\Models\Component;
+use CycloneDX\Core\Models\MetaData;
+use CycloneDX\Core\Repositories\ToolRepository;
+use CycloneDX\Core\Serialize\JSON\NormalizerFactory;
+use CycloneDX\Core\Serialize\JSON\Normalizers\ComponentNormalizer;
+use CycloneDX\Core\Serialize\JSON\Normalizers\MetaDataNormalizer;
+use CycloneDX\Core\Serialize\JSON\Normalizers\ToolRepositoryNormalizer;
+use CycloneDX\Core\Spec\SpecInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \CycloneDX\Core\Serialize\JSON\Normalizers\MetaDataNormalizer
+ * @covers \CycloneDX\Core\Serialize\JSON\AbstractNormalizer
+ */
+class MetaDataNormalizerTest extends TestCase
+{
+    public function testNormalizeEmpty(): void
+    {
+        $metaData = $this->createMock(MetaData::class);
+        $spec = $this->createMock(SpecInterface::class);
+        $factory = $this->createConfiguredMock(NormalizerFactory::class, ['getSpec' => $spec]);
+        $normalizer = new MetaDataNormalizer($factory);
+
+        $actual = $normalizer->normalize($metaData);
+
+        self::assertSame([], $actual);
+    }
+
+    public function testNormalizeTools(): void
+    {
+        $metaData = $this->createConfiguredMock(
+            MetaData::class,
+            [
+                'getTools' => $this->createConfiguredMock(ToolRepository::class, ['count' => 2]),
+            ]
+        );
+        $spec = $this->createMock(SpecInterface::class);
+        $toolsRepoFactory = $this->createMock(ToolRepositoryNormalizer::class);
+        $factory = $this->createConfiguredMock(
+            NormalizerFactory::class,
+            [
+                'getSpec' => $spec,
+                'makeForToolRepository' => $toolsRepoFactory,
+            ]
+        );
+        $normalizer = new MetaDataNormalizer($factory);
+
+        $toolsRepoFactory->expects(self::once())
+            ->method('normalize')
+            ->with($metaData->getTools())
+            ->willReturn(['FakeTool' => 'dummy']);
+
+        $actual = $normalizer->normalize($metaData);
+
+        self::assertSame(
+            ['tools' => ['FakeTool' => 'dummy']],
+            $actual
+        );
+    }
+
+    public function testNormalizeComponent(): void
+    {
+        $metaData = $this->createConfiguredMock(
+            MetaData::class,
+            [
+                'getComponent' => $this->createMock(Component::class),
+            ]
+        );
+        $spec = $this->createMock(SpecInterface::class);
+        $componentFactory = $this->createMock(ComponentNormalizer::class);
+        $factory = $this->createConfiguredMock(
+            NormalizerFactory::class,
+            [
+                'getSpec' => $spec,
+                'makeForComponent' => $componentFactory,
+            ]
+        );
+        $normalizer = new MetaDataNormalizer($factory);
+
+        $componentFactory->expects(self::once())
+            ->method('normalize')
+            ->with($metaData->getComponent())
+            ->willReturn(['FakeComponent' => 'dummy']);
+
+        $actual = $normalizer->normalize($metaData);
+
+        self::assertSame(
+            ['component' => ['FakeComponent' => 'dummy']],
+            $actual
+        );
+    }
+
+    public function testNormalizeComponentUnsupported(): void
+    {
+        $metaData = $this->createConfiguredMock(
+            MetaData::class,
+            [
+                'getComponent' => $this->createMock(Component::class),
+            ]
+        );
+        $spec = $this->createMock(SpecInterface::class);
+        $componentFactory = $this->createMock(ComponentNormalizer::class);
+        $factory = $this->createConfiguredMock(
+            NormalizerFactory::class,
+            [
+                'getSpec' => $spec,
+                'makeForComponent' => $componentFactory,
+            ]
+        );
+        $normalizer = new MetaDataNormalizer($factory);
+
+        $componentFactory->expects(self::once())
+            ->method('normalize')
+            ->with($metaData->getComponent())
+            ->willThrowException(new \DomainException());
+
+        $actual = $normalizer->normalize($metaData);
+
+        self::assertSame([], $actual);
+    }
+}

--- a/tests/Core/Serialize/JSON/Normalizers/ToolNormalizerTest.php
+++ b/tests/Core/Serialize/JSON/Normalizers/ToolNormalizerTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of CycloneDX PHP Composer Plugin.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+
+namespace CycloneDX\Tests\Core\Serialize\JSON\Normalizers;
+
+use CycloneDX\Core\Models\Tool;
+use CycloneDX\Core\Repositories\HashRepository;
+use CycloneDX\Core\Serialize\JSON\NormalizerFactory;
+use CycloneDX\Core\Serialize\JSON\Normalizers\HashRepositoryNormalizer;
+use CycloneDX\Core\Serialize\JSON\Normalizers\ToolNormalizer;
+use CycloneDX\Core\Spec\SpecInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \CycloneDX\Core\Serialize\JSON\Normalizers\ToolNormalizer
+ *
+ * @uses   \CycloneDX\Core\Serialize\JSON\AbstractNormalizer
+ */
+class ToolNormalizerTest extends TestCase
+{
+    public function testNormalizeEmpty(): void
+    {
+        $tool = $this->createMock(Tool::class);
+        $spec = $this->createMock(SpecInterface::class);
+        $factory = $this->createConfiguredMock(NormalizerFactory::class, ['getSpec' => $spec]);
+        $normalizer = new ToolNormalizer($factory);
+
+        $actual = $normalizer->normalize($tool);
+
+        self::assertSame([], $actual);
+    }
+
+    public function testNormalize(): void
+    {
+        $tool = $this->createConfiguredMock(
+            Tool::class,
+            [
+                'getVendor' => 'myVendor',
+                'getName' => 'myName',
+                'getVersion' => 'myVersion',
+                'getHashRepository' => $this->createConfiguredMock(HashRepository::class, ['count' => 2]),
+            ]
+        );
+        $spec = $this->createMock(SpecInterface::class);
+        $hashRepoNormalizer = $this->createMock(HashRepositoryNormalizer::class, );
+        $factory = $this->createConfiguredMock(
+            NormalizerFactory::class,
+            [
+                'getSpec' => $spec,
+                'makeForHashRepository' => $hashRepoNormalizer,
+            ]
+        );
+        $normalizer = new ToolNormalizer($factory);
+
+        $hashRepoNormalizer->expects(self::once())
+            ->method('normalize')
+            ->with($tool->getHashRepository())
+            ->willReturn(['FakeHash' => 'dummy']);
+
+        $actual = $normalizer->normalize($tool);
+
+        self::assertSame(
+            [
+                'vendor' => 'myVendor',
+                'name' => 'myName',
+                'version' => 'myVersion',
+                'hashes' => ['FakeHash' => 'dummy'],
+            ],
+            $actual
+        );
+    }
+}

--- a/tests/Core/Serialize/JSON/Normalizers/ToolRepositoryNormalizerTest.php
+++ b/tests/Core/Serialize/JSON/Normalizers/ToolRepositoryNormalizerTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of CycloneDX PHP Composer Plugin.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+
+namespace CycloneDX\Tests\Core\Serialize\JSON\Normalizers;
+
+use CycloneDX\Core\Models\Tool;
+use CycloneDX\Core\Repositories\ToolRepository;
+use CycloneDX\Core\Serialize\JSON\NormalizerFactory;
+use CycloneDX\Core\Serialize\JSON\Normalizers\ToolNormalizer;
+use CycloneDX\Core\Serialize\JSON\Normalizers\ToolRepositoryNormalizer;
+use CycloneDX\Core\Spec\SpecInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \CycloneDX\Core\Serialize\JSON\Normalizers\ToolRepositoryNormalizer
+ * @covers \CycloneDX\Core\Serialize\JSON\AbstractNormalizer
+ */
+class ToolRepositoryNormalizerTest extends TestCase
+{
+    /**
+     * @uses \CycloneDX\Core\Serialize\JSON\Normalizers\ToolNormalizer
+     */
+    public function testNormalizeEmpty(): void
+    {
+        $spec = $this->createStub(SpecInterface::class);
+        $factory = $this->createConfiguredMock(NormalizerFactory::class, ['getSpec' => $spec]);
+        $normalizer = new ToolRepositoryNormalizer($factory);
+        $tools = $this->createConfiguredMock(ToolRepository::class, ['count' => 0]);
+
+        $actual = $normalizer->normalize($tools);
+
+        self::assertSame([], $actual);
+    }
+
+    public function testNormalize(): void
+    {
+        $spec = $this->createStub(SpecInterface::class);
+        $toolNormalizer = $this->createMock(ToolNormalizer::class);
+        $factory = $this->createConfiguredMock(NormalizerFactory::class, [
+            'getSpec' => $spec,
+            'makeForTool' => $toolNormalizer,
+        ]);
+        $normalizer = new ToolRepositoryNormalizer($factory);
+        $tool = $this->createStub(Tool::class);
+        $tools = $this->createConfiguredMock(ToolRepository::class, [
+            'count' => 1,
+            'getTools' => [$tool],
+        ]);
+
+        $toolNormalizer->expects(self::once())->method('normalize')
+            ->with($tool)
+            ->willReturn(['FakeTool' => 'dummy']);
+
+        $actual = $normalizer->normalize($tools);
+
+        self::assertSame([['FakeTool' => 'dummy']], $actual);
+    }
+
+    public function testNormalizeSkipsOnThrow(): void
+    {
+        $spec = $this->createStub(SpecInterface::class);
+        $toolNormalizer = $this->createMock(ToolNormalizer::class);
+        $factory = $this->createConfiguredMock(NormalizerFactory::class, [
+            'getSpec' => $spec,
+            'makeForTool' => $toolNormalizer,
+        ]);
+        $normalizer = new ToolRepositoryNormalizer($factory);
+        $tool1 = $this->createStub(Tool::class);
+        $tool2 = $this->createStub(Tool::class);
+        $tools = $this->createConfiguredMock(ToolRepository::class, [
+            'count' => 1,
+            'getTools' => [$tool1, $tool2],
+        ]);
+
+        $toolNormalizer->expects(self::exactly(2))->method('normalize')
+            ->withConsecutive([$tool1], [$tool2])
+            ->willThrowException(new \DomainException());
+
+        $actual = $normalizer->normalize($tools);
+
+        self::assertSame([], $actual);
+    }
+}

--- a/tests/Core/Serialize/JsonSerializerTest.php
+++ b/tests/Core/Serialize/JsonSerializerTest.php
@@ -36,29 +36,36 @@ class JsonSerializerTest extends TestCase
     /**
      * @covers \CycloneDX\Core\Serialize\JsonSerializer
      *
-     * @uses \CycloneDX\Core\Serialize\JSON\AbstractNormalizer
-     * @uses \CycloneDX\Core\Serialize\JSON\NormalizerFactory
-     * @uses \CycloneDX\Core\Serialize\JSON\Normalizers\BomNormalizer
-     * @uses \CycloneDX\Core\Serialize\JSON\Normalizers\ComponentRepositoryNormalizer
+     * @uses   \CycloneDX\Core\Serialize\JSON\AbstractNormalizer
+     * @uses   \CycloneDX\Core\Serialize\JSON\NormalizerFactory
+     * @uses   \CycloneDX\Core\Serialize\JSON\Normalizers\BomNormalizer
+     * @uses   \CycloneDX\Core\Serialize\JSON\Normalizers\ComponentRepositoryNormalizer
+     * @uses   \CycloneDX\Core\Serialize\JSON\Normalizers\ComponentNormalizer
      */
     public function testSerialize(): void
     {
-        $spec = $this->createConfiguredMock(SpecInterface::class, [
-            'getVersion' => '1.2',
-            'isSupportedFormat' => true,
-            ]);
+        $spec = $this->createConfiguredMock(
+            SpecInterface::class,
+            [
+                'getVersion' => '1.2',
+                'isSupportedFormat' => true,
+            ]
+        );
         $serializer = new JsonSerializer($spec);
         $bom = $this->createStub(Bom::class);
 
-        $got = $serializer->serialize($bom);
+        $actual = $serializer->serialize($bom);
 
-        self::assertJsonStringEqualsJsonString(<<<'JSON'
-            {
-                "bomFormat": "CycloneDX",
-                "specVersion": "1.2",
-                "version": 0,
-                "components": []
-            }
-            JSON, $got);
+        self::assertJsonStringEqualsJsonString(
+            <<<'JSON'
+                {
+                    "bomFormat": "CycloneDX",
+                    "specVersion": "1.2",
+                    "version": 0,
+                    "components": []
+                }
+                JSON,
+            $actual
+        );
     }
 }

--- a/tests/Core/Serialize/XmlSerializerTest.php
+++ b/tests/Core/Serialize/XmlSerializerTest.php
@@ -40,6 +40,7 @@ class XmlSerializerTest extends TestCase
      * @uses   \CycloneDX\Core\Serialize\DOM\NormalizerFactory
      * @uses   \CycloneDX\Core\Serialize\DOM\Normalizers\BomNormalizer
      * @uses   \CycloneDX\Core\Serialize\DOM\Normalizers\ComponentRepositoryNormalizer
+     * @uses   \CycloneDX\Core\Serialize\DOM\Normalizers\ComponentNormalizer
      */
     public function testSerialize(): void
     {
@@ -53,14 +54,16 @@ class XmlSerializerTest extends TestCase
         $serializer = new XmlSerializer($spec);
         $bom = $this->createStub(Bom::class);
 
-        $got = $serializer->serialize($bom);
+        $actual = $serializer->serialize($bom);
 
-        self::assertXmlStringEqualsXmlString(<<<'XML'
-            <?xml version="1.0" encoding="UTF-8"?>
-            <bom xmlns="http://cyclonedx.org/schema/bom/1.2" version="0">
-              <components/>
-            </bom>
-            XML, $got
+        self::assertXmlStringEqualsXmlString(
+            <<<'XML'
+                <?xml version="1.0" encoding="UTF-8"?>
+                <bom xmlns="http://cyclonedx.org/schema/bom/1.2" version="0">
+                  <components/>
+                </bom>
+                XML,
+            $actual
         );
     }
 }

--- a/tests/Core/SerializeToJsonTest.php
+++ b/tests/Core/SerializeToJsonTest.php
@@ -21,7 +21,7 @@ declare(strict_types=1);
  * Copyright (c) Steve Springett. All Rights Reserved.
  */
 
-namespace CycloneDX\Tests\Core\Serialize;
+namespace CycloneDX\Tests\Core;
 
 use CycloneDX\Core\Models\Bom;
 use CycloneDX\Core\Serialize\JsonSerializer;
@@ -35,7 +35,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * @coversNothing
  */
-class JsonTest extends TestCase
+class SerializeToJsonTest extends TestCase
 {
     // region Spec 1.0
     // Spec 1.0 is not implemented
@@ -65,9 +65,7 @@ class JsonTest extends TestCase
      * This test might be slow.
      * This test might require online-connectivity.
      *
-     * @dataProvider \CycloneDX\Tests\_data\BomModelProvider::fullBomTestData
-     * @dataProvider \CycloneDX\Tests\_data\BomModelProvider::bomWithComponentHashAlgorithmsSpec12()
-     * @dataProvider \CycloneDX\Tests\_data\BomModelProvider::bomWithComponentTypeSpec12()
+     * @dataProvider \CycloneDX\Tests\_data\BomModelProvider::allBomTestData
      */
     public function testSchema12(Bom $bom): void
     {
@@ -89,9 +87,7 @@ class JsonTest extends TestCase
      * This test might be slow.
      * This test might require online-connectivity.
      *
-     * @dataProvider \CycloneDX\Tests\_data\BomModelProvider::fullBomTestData
-     * @dataProvider \CycloneDX\Tests\_data\BomModelProvider::bomWithComponentHashAlgorithmsSpec13()
-     * @dataProvider \CycloneDX\Tests\_data\BomModelProvider::bomWithComponentTypeSpec13()
+     * @dataProvider \CycloneDX\Tests\_data\BomModelProvider::allBomTestData
      */
     public function testSchema13(Bom $bom): void
     {

--- a/tests/Core/SerializeToXmlTest.php
+++ b/tests/Core/SerializeToXmlTest.php
@@ -21,7 +21,7 @@ declare(strict_types=1);
  * Copyright (c) Steve Springett. All Rights Reserved.
  */
 
-namespace CycloneDX\Tests\Core\Serialize;
+namespace CycloneDX\Tests\Core;
 
 use CycloneDX\Core\Models\Bom;
 use CycloneDX\Core\Serialize\XmlSerializer;
@@ -34,7 +34,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * @coversNothing
  */
-class XmlTest extends TestCase
+class SerializeToXmlTest extends TestCase
 {
     // region Spec 1.0
     // Spec 1.0 is not implemented
@@ -46,9 +46,7 @@ class XmlTest extends TestCase
      * This test might be slow.
      * This test might require online-connectivity.
      *
-     * @dataProvider \CycloneDX\Tests\_data\BomModelProvider::fullBomTestData
-     * @dataProvider \CycloneDX\Tests\_data\BomModelProvider::bomWithComponentHashAlgorithmsSpec11()
-     * @dataProvider \CycloneDX\Tests\_data\BomModelProvider::bomWithComponentTypeSpec11()
+     * @dataProvider \CycloneDX\Tests\_data\BomModelProvider::allBomTestData
      */
     public function testSchema11(Bom $bom): void
     {
@@ -70,9 +68,7 @@ class XmlTest extends TestCase
      * This test might be slow.
      * This test might require online-connectivity.
      *
-     * @dataProvider \CycloneDX\Tests\_data\BomModelProvider::fullBomTestData
-     * @dataProvider \CycloneDX\Tests\_data\BomModelProvider::bomWithComponentHashAlgorithmsSpec12()
-     * @dataProvider \CycloneDX\Tests\_data\BomModelProvider::bomWithComponentTypeSpec12()
+     * @dataProvider \CycloneDX\Tests\_data\BomModelProvider::allBomTestData
      */
     public function testSchema12(Bom $bom): void
     {
@@ -94,9 +90,7 @@ class XmlTest extends TestCase
      * This test might be slow.
      * This test might require online-connectivity.
      *
-     * @dataProvider \CycloneDX\Tests\_data\BomModelProvider::fullBomTestData
-     * @dataProvider \CycloneDX\Tests\_data\BomModelProvider::bomWithComponentHashAlgorithmsSpec13()
-     * @dataProvider \CycloneDX\Tests\_data\BomModelProvider::bomWithComponentTypeSpec13()
+     * @dataProvider \CycloneDX\Tests\_data\BomModelProvider::allBomTestData
      */
     public function testSchema13(Bom $bom): void
     {

--- a/tests/Core/Spec/AbstractSpecTestCase.php
+++ b/tests/Core/Spec/AbstractSpecTestCase.php
@@ -166,4 +166,12 @@ abstract class AbstractSpecTestCase extends TestCase
     }
 
     abstract public function shouldSupportLicenseExpression(): bool;
+
+    final public function testSupportsMetaData(): void
+    {
+        $isSupported = $this->getSpec()->supportsMetaData();
+        self::assertSame($this->shouldSupportMetaData(), $isSupported);
+    }
+
+    abstract public function shouldSupportMetaData(): bool;
 }

--- a/tests/Core/Spec/Spec11Test.php
+++ b/tests/Core/Spec/Spec11Test.php
@@ -51,4 +51,9 @@ class Spec11Test extends AbstractSpecTestCase
     {
         return true;
     }
+
+    public function shouldSupportMetaData(): bool
+    {
+        return false;
+    }
 }

--- a/tests/Core/Spec/Spec12Test.php
+++ b/tests/Core/Spec/Spec12Test.php
@@ -51,4 +51,9 @@ class Spec12Test extends AbstractSpecTestCase
     {
         return true;
     }
+
+    public function shouldSupportMetaData(): bool
+    {
+        return true;
+    }
 }

--- a/tests/Core/Spec/Spec13Test.php
+++ b/tests/Core/Spec/Spec13Test.php
@@ -51,4 +51,9 @@ class Spec13Test extends AbstractSpecTestCase
     {
         return true;
     }
+
+    public function shouldSupportMetaData(): bool
+    {
+        return true;
+    }
 }

--- a/tests/Core/Validation/ValidationErrorTest.php
+++ b/tests/Core/Validation/ValidationErrorTest.php
@@ -38,5 +38,6 @@ class ValidationErrorTest extends TestCase
         $error = ValidationError::fromThrowable($throwable);
 
         self::assertSame('foo bar', $error->getMessage());
+        self::assertSame($throwable, $error->getError());
     }
 }


### PR DESCRIPTION
* Changed
  * Core library
    * SerializersGroups will skipp unsupported elements silently, instead of forwarding caught exceptions.
      This results in an overall smoother SBoM generation process, just as intended.
* Added
  * CLI via `composer make-bom`
    * Will try to populate metadata of the SBoM.
  * Core library
    * Added models for spec elements: `metadata`, `tools`, `tool`
    * Added ability to serialize `metadata` to XML
    * Added ability to serialize `metadata` to JSON
* Fixed
  * CLI via `composer make-bom`
    * composer packages of type `project` or `composer-plugin`
      result as CycloneDX component of type `application`, was `library`.
* Misc
  * Split some tests to more fine-grained scenarios.

closes #14 

----

status 
- [x] implemented & tested
- [x] updated examples & docs
- [x] reviewed
- [x] consolidate commits / re-split the commits