### PR TITLE
Improved compatibility to composer

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## unreleased
 
+* Fixed
+  * Improved compatibility to composer. (via [#125])    
+    This was made possible since composer's type hints are getting fixed.
+    See https://github.com/composer/composer/releases/tag/2.1.7
+    > Added many type annotations internally, which may have an effect on CI/static analysis for people using Composer as a dependency.
+
+[#125]: https://github.com/CycloneDX/cyclonedx-php-composer/pull/125
+
 ## 3.4.0 - 2021-09-12
 
 * Changed

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -4,7 +4,7 @@
        xsi:schemaLocation="https://getpsalm.org/schema/config tools/psalm/vendor/vimeo/psalm/config.xsd"
        errorLevel="1"
        checkForThrowsDocblock="true"
-       findUnusedPsalmSuppress="true"
+       findUnusedPsalmSuppress="false"
        ensureArrayStringOffsetsExist="true"
        ensureArrayIntOffsetsExist="true"
        cacheDirectory=".psalm.cache"

--- a/src/Composer/MakeBom/Command.php
+++ b/src/Composer/MakeBom/Command.php
@@ -247,10 +247,22 @@ class Command extends BaseCommand
                 throw new \UnexpectedValueException('empty composer');
             }
 
-            $withDevReqs = !empty($composer->getLocker()->getDevPackageNames());
-            $lockerRepo = $composer->getLocker()->getLockedRepository($withDevReqs);
-            // @TODO better use the installed-repo than the lockerRepo - as of milestone v4
+            /**
+             * Composer <  2.1.7 -> nullable, but type hint was wrong
+             * Composer >= 2.1.7 -> nullable.
+             *
+             * @var \Composer\Package\Locker|null
+             * @psalm-suppress UnnecessaryVarAnnotation
+             */
+            $locker = $composer->getLocker();
+            if (null === $locker) {
+                throw new \UnexpectedValueException('empty locker');
+            }
 
+            $withDevReqs = !empty($locker->getDevPackageNames());
+            $lockerRepo = $locker->getLockedRepository($withDevReqs);
+
+            // @TODO better use the installed-repo than the lockerRepo - as of milestone v4
             return $updater->updateTool($this->bomFactory->getTool(), $lockerRepo);
         } catch (\Exception $exception) {
             return false;

--- a/src/Composer/MakeBom/Factory.php
+++ b/src/Composer/MakeBom/Factory.php
@@ -124,8 +124,16 @@ class Factory
         Composer $composer,
         Options $options
     ): LockArrayRepository {
+        /**
+         * Composer <  2.1.7 -> nullable, but type hint was wrong
+         * Composer >= 2.1.7 -> nullable.
+         *
+         * @var \Composer\Package\Locker|null
+         * @psalm-suppress UnnecessaryVarAnnotation
+         */
         $locker = $composer->getLocker();
-        if (!$locker->isLocked() || !$locker->isFresh()) {
+
+        if (null === $locker || !$locker->isLocked() || !$locker->isFresh()) {
             throw new Exceptions\LockerIsOutdatedError('The lock file is missing or not up to date with composer config');
         }
 


### PR DESCRIPTION
This was made possible since composer's type hints are getting fixed.
See https://github.com/composer/composer/releases/tag/2.1.7
> Added many type annotations internally, which may have an effect on CI/static analysis for people using Composer as a dependency.
> This work will continue in following releases