### PR TITLE
omit `metadata.component.purl`'s version, if version auto-detection fails

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -8,8 +8,13 @@ All notable changes to this project will be documented in this file.
   * CLI got new option `--mc-version`. (via [#133])  
     That allows to set the main component's version in the resulting SBoM,
     so that the auto-detection can be overridden.
+* Fixed
+  * The resulting SBoM's main component's `purl` does not get a version assigned,
+    if the version auto-detection fails. (via [#134])
 
 [#133]: https://github.com/CycloneDX/cyclonedx-php-composer/pull/133
+[#134]: https://github.com/CycloneDX/cyclonedx-php-composer/pull/134
+
 
 ## 3.5.0 - 2021-10-07
 

--- a/src/Builders/ComponentBuilder.php
+++ b/src/Builders/ComponentBuilder.php
@@ -25,6 +25,7 @@ namespace CycloneDX\Composer\Builders;
 
 use Composer\Package\CompletePackageInterface;
 use Composer\Package\PackageInterface;
+use Composer\Package\RootPackage;
 use CycloneDX\Composer\Factories\LicenseFactory;
 use CycloneDX\Composer\Factories\PackageUrlFactory;
 use CycloneDX\Core\Enums\Classification;
@@ -100,6 +101,11 @@ class ComponentBuilder
 
         try {
             $purl = $this->packageUrlFactory->makeFromComponent($component);
+            if ($package instanceof RootPackage
+                && RootPackage::DEFAULT_PRETTY_VERSION === $version
+            ) {
+                $purl->setVersion(null);
+            }
             $component->setPackageUrl($purl);
             $component->setBomRefValue((string) $purl);
         } catch (DomainException $exception) {

--- a/tests/Builders/ComponentBuilderTest.php
+++ b/tests/Builders/ComponentBuilderTest.php
@@ -25,6 +25,7 @@ namespace Tests\Builders;
 
 use Composer\Package\CompletePackageInterface;
 use Composer\Package\PackageInterface;
+use Composer\Package\RootPackage;
 use CycloneDX\Composer\Builders\ComponentBuilder;
 use CycloneDX\Composer\Factories\LicenseFactory;
 use CycloneDX\Composer\Factories\PackageUrlFactory;
@@ -217,6 +218,21 @@ class ComponentBuilderTest extends TestCase
             (new Component('library', 'some-inDev', 'dev-master'))
                 ->setPackageUrl((new PackageUrl('composer', 'some-inDev'))->setVersion('dev-master'))
                 ->setBomRefValue('pkg:composer/some-inDev@dev-master'),
+            null,
+        ];
+
+        yield 'minimal without version' => [
+            $this->createConfiguredMock(
+                RootPackage::class,
+                [
+                    'getType' => 'myType',
+                    'getPrettyName' => 'some-noVersion',
+                    'getPrettyVersion' => RootPackage::DEFAULT_PRETTY_VERSION,
+                ],
+            ),
+            (new Component('library', 'some-noVersion', RootPackage::DEFAULT_PRETTY_VERSION))
+                ->setPackageUrl((new PackageUrl('composer', 'some-noVersion'))->setVersion(null))
+                ->setBomRefValue('pkg:composer/some-noVersion'),
             null,
         ];
 


### PR DESCRIPTION
related to #132

----

TODO

- [x] finish implementation
- [x] write HISTORY