### PR TITLE
added CLI switch `--no-version-normalization`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ## unreleased
 
+* Added
+  * CLI got a new switch `--no-version-normalization`. (via [#138])  
+    That allows to omit component version-string normalization.  
+    Per default this plugin will normalize version strings by stripping leading "v".  
+    This is a compatibility-switch. The next major-version of this plugin will not modify component versions. (see [#102])
+
+[#138]: https://github.com/CycloneDX/cyclonedx-php-composer/pull/138
+[#102]: https://github.com/CycloneDX/cyclonedx-php-composer/issues/102
+
+
+
 ## 3.6.0 - 2021-10-15
 
 * Added

--- a/README.md
+++ b/README.md
@@ -47,9 +47,12 @@ Options:
       --exclude-plugins              Exclude composer plugins
       --spec-version=SPEC-VERSION    Which version of CycloneDX spec to use.
                                      Values: "1.1", "1.2", "1.3" [default: "1.3"]
-      --no-validate                  Dont validate the resulting output
+      --no-validate                  Don't validate the resulting output
       --mc-version=MC-VERSION        Version of the main component.
                                      This will override auto-detection.
+      --no-version-normalization     Don't normalize component version strings.
+                                     Per default this plugin will normalize version strings by stripping leading "v".
+                                     This is a compatibility-switch. The next major-version of this plugin will not modify component versions.
   -h, --help                         Display this help message
   -q, --quiet                        Do not output any message
   -V, --version                      Display this application version

--- a/src/MakeBom/Options.php
+++ b/src/MakeBom/Options.php
@@ -46,6 +46,10 @@ class Options
     private const SWITCH_EXCLUDE_PLUGINS = 'exclude-plugins';
     private const SWITCH_NO_VALIDATE = 'no-validate';
 
+    // added in preparation for https://github.com/CycloneDX/cyclonedx-php-composer/issues/102
+    // @TODO remove with next major version
+    private const SWITCH_NO_VERSION_NORMALIZATION = 'no-version-normalization';
+
     private const ARGUMENT_COMPOSER_FILE = 'composer-file';
 
     public const OUTPUT_FORMAT_XML = 'XML';
@@ -111,7 +115,7 @@ class Options
                 self::SWITCH_NO_VALIDATE,
                 null,
                 InputOption::VALUE_NONE,
-                'Dont validate the resulting output'
+                'Don\'t validate the resulting output'
             )
             ->addOption(
                 self::OPTION_MAIN_COMPONENT_VERSION,
@@ -120,6 +124,14 @@ class Options
                 'Version of the main component.'.\PHP_EOL.
                 'This will override auto-detection.',
                 null
+            )
+            ->addOption(
+                self::SWITCH_NO_VERSION_NORMALIZATION,
+                null,
+                InputOption::VALUE_NONE,
+                'Don\'t normalize component version strings.'.\PHP_EOL.
+                'Per default this plugin will normalize version strings by stripping leading "v".'.\PHP_EOL.
+                'This is a compatibility-switch. The next major-version of this plugin will not modify component versions.'
             )
             ->addArgument(
                 self::ARGUMENT_COMPOSER_FILE,
@@ -150,6 +162,13 @@ class Options
      * @psalm-allow-private-mutation
      */
     public $excludePlugins = false;
+
+    /**
+     * @var bool
+     * @readonly
+     * @psalm-allow-private-mutation
+     */
+    public $omitVersionNormalization = false;
 
     /**
      * @var string
@@ -214,6 +233,7 @@ class Options
         $excludeDev = false !== $input->getOption(self::SWITCH_EXCLUDE_DEV);
         $excludePlugins = false !== $input->getOption(self::SWITCH_EXCLUDE_PLUGINS);
         $skipOutputValidation = false !== $input->getOption(self::SWITCH_NO_VALIDATE);
+        $omitVersionNormalization = false !== $input->getOption(self::SWITCH_NO_VERSION_NORMALIZATION);
         $outputFile = $input->getOption(self::OPTION_OUTPUT_FILE);
         \assert(null === $outputFile || \is_string($outputFile));
         $composerFile = $input->getArgument(self::ARGUMENT_COMPOSER_FILE);
@@ -233,6 +253,7 @@ class Options
         $this->excludePlugins = $excludePlugins;
         $this->outputFormat = $outputFormat;
         $this->skipOutputValidation = $skipOutputValidation;
+        $this->omitVersionNormalization = $omitVersionNormalization;
         $this->outputFile = \is_string($outputFile) && '' !== $outputFile
             ? $outputFile
             : self::OUTPUT_FILE_DEFAULT[$outputFormat];

--- a/tests/Builders/ComponentBuilderTest.php
+++ b/tests/Builders/ComponentBuilderTest.php
@@ -130,12 +130,14 @@ class ComponentBuilderTest extends TestCase
     public function testMakeFromPackage(
         PackageInterface $package,
         Component $expected,
+        bool $enableVersionNormalization = true,
         ?LicenseFactory $licenseFactory = null
     ): void {
         $packageUrlFactory = $this->createMock(PackageUrlFactory::class);
         $builder = new ComponentBuilder(
             $licenseFactory ?? $this->createStub(LicenseFactory::class),
-            $packageUrlFactory
+            $packageUrlFactory,
+            $enableVersionNormalization
         );
 
         $purlMadeFromComponent = null;
@@ -172,6 +174,7 @@ class ComponentBuilderTest extends TestCase
             (new Component('library', 'some-library', '1.2.3'))
                 ->setPackageUrl((new PackageUrl('composer', 'some-library'))->setVersion('1.2.3'))
                 ->setBomRefValue('pkg:composer/some-library@1.2.3'),
+            true,
             null,
         ];
 
@@ -187,6 +190,7 @@ class ComponentBuilderTest extends TestCase
             (new Component('application', 'some-project', '1.2.3'))
                 ->setPackageUrl((new PackageUrl('composer', 'some-project'))->setVersion('1.2.3'))
                 ->setBomRefValue('pkg:composer/some-project@1.2.3'),
+            true,
             null,
         ];
 
@@ -202,6 +206,7 @@ class ComponentBuilderTest extends TestCase
             (new Component('application', 'some-composer-plugin', '1.2.3'))
                 ->setPackageUrl((new PackageUrl('composer', 'some-composer-plugin'))->setVersion('1.2.3'))
                 ->setBomRefValue('pkg:composer/some-composer-plugin@1.2.3'),
+            true,
             null,
         ];
 
@@ -218,6 +223,7 @@ class ComponentBuilderTest extends TestCase
             (new Component('library', 'some-inDev', 'dev-master'))
                 ->setPackageUrl((new PackageUrl('composer', 'some-inDev'))->setVersion('dev-master'))
                 ->setBomRefValue('pkg:composer/some-inDev@dev-master'),
+            true,
             null,
         ];
 
@@ -233,6 +239,7 @@ class ComponentBuilderTest extends TestCase
             (new Component('library', 'some-noVersion', RootPackage::DEFAULT_PRETTY_VERSION))
                 ->setPackageUrl((new PackageUrl('composer', 'some-noVersion'))->setVersion(null))
                 ->setBomRefValue('pkg:composer/some-noVersion'),
+            true,
             null,
         ];
 
@@ -266,7 +273,28 @@ class ComponentBuilderTest extends TestCase
                 ->setLicense($license)
                 ->setHashRepository(new HashRepository([HashAlgorithm::SHA_1 => '12345678901234567890123456789012']))
                 ->setBomRefValue('pkg:composer/my/package@1.2.3?checksum=sha1:12345678901234567890123456789012'),
+            true,
             $licenseFactory,
+        ];
+
+        yield 'library with non-normalized version' => [
+            $this->createConfiguredMock(
+                CompletePackageInterface::class,
+                [
+                    'getPrettyName' => 'my/package',
+                    'getPrettyVersion' => 'v1.2.3',
+                ]
+            ),
+            (new Component('library', 'package', 'v1.2.3'))
+                ->setGroup('my')
+                ->setPackageUrl(
+                    (new PackageUrl('composer', 'package'))
+                        ->setNamespace('my')
+                        ->setVersion('v1.2.3')
+                )
+                ->setBomRefValue('pkg:composer/my/package@v1.2.3'),
+            false,
+            null,
         ];
     }
 }

--- a/tests/MakeBom/OptionsTest.php
+++ b/tests/MakeBom/OptionsTest.php
@@ -90,6 +90,9 @@ class OptionsTest extends TestCase
             ['--spec-version=1.1', 'specVersion', Version::V_1_1],
             ['--spec-version=1.2', 'specVersion', Version::V_1_2],
             ['--spec-version=1.3', 'specVersion', Version::V_1_3],
+            /* @see \CycloneDX\Composer\MakeBom\Options::$omitVersionNormalization */
+            'omitVersionNormalization default' => ['', 'omitVersionNormalization', false],
+            ['--no-version-normalization', 'omitVersionNormalization', true],
             /* @see \CycloneDX\Composer\MakeBom\Options::$composerFile */
             'composerFile default to null' => ['', 'composerFile', null],
             ['my/project/composer.json', 'composerFile', 'my/project/composer.json'],


### PR DESCRIPTION
is related to #102

CLI got a new switch `--no-version-normalization`.
    That allows to omit component version-string normalization.  
    Per default this plugin will normalize version strings by stripping leading "v".  
    This is a compatibility-switch. The next major-version of this plugin will not modify component versions.
