### PR TITLE
move tests in `CycloneDX` namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Tests\\": "tests/"
+            "CycloneDX\\Tests\\": "tests/"
         }
     },
     "prefer-stable": true,

--- a/tests/Builders/BomBuilderTest.php
+++ b/tests/Builders/BomBuilderTest.php
@@ -21,7 +21,7 @@ declare(strict_types=1);
  * Copyright (c) Steve Springett. All Rights Reserved.
  */
 
-namespace Tests\Builders;
+namespace CycloneDX\Tests\Builders;
 
 use Composer\Package\Link;
 use Composer\Package\PackageInterface;

--- a/tests/Builders/ComponentBuilderTest.php
+++ b/tests/Builders/ComponentBuilderTest.php
@@ -21,7 +21,7 @@ declare(strict_types=1);
  * Copyright (c) Steve Springett. All Rights Reserved.
  */
 
-namespace Tests\Builders;
+namespace CycloneDX\Tests\Builders;
 
 use Composer\Package\CompletePackageInterface;
 use Composer\Package\PackageInterface;

--- a/tests/Factories/LicenseFactoryTest.php
+++ b/tests/Factories/LicenseFactoryTest.php
@@ -21,7 +21,7 @@ declare(strict_types=1);
  * Copyright (c) Steve Springett. All Rights Reserved.
  */
 
-namespace Tests\Factories;
+namespace CycloneDX\Tests\Factories;
 
 use Composer\Package\CompletePackageInterface;
 use CycloneDX\Composer\Factories\LicenseFactory;

--- a/tests/Factories/PackageUrlFactoryTest.php
+++ b/tests/Factories/PackageUrlFactoryTest.php
@@ -21,7 +21,7 @@ declare(strict_types=1);
  * Copyright (c) Steve Springett. All Rights Reserved.
  */
 
-namespace Tests\Factories;
+namespace CycloneDX\Tests\Factories;
 
 use CycloneDX\Composer\Factories\PackageUrlFactory;
 use CycloneDX\Core\Models\Component;

--- a/tests/Factories/SpecFactoryTest.php
+++ b/tests/Factories/SpecFactoryTest.php
@@ -21,7 +21,7 @@ declare(strict_types=1);
  * Copyright (c) Steve Springett. All Rights Reserved.
  */
 
-namespace Tests\Factories;
+namespace CycloneDX\Tests\Factories;
 
 use CycloneDX\Composer\Factories\SpecFactory;
 use CycloneDX\Core\Spec\Spec11;

--- a/tests/MakeBom/CommandTest.php
+++ b/tests/MakeBom/CommandTest.php
@@ -21,7 +21,7 @@ declare(strict_types=1);
  * Copyright (c) Steve Springett. All Rights Reserved.
  */
 
-namespace Tests\MakeBom;
+namespace CycloneDX\Tests\MakeBom;
 
 use Composer\IO\NullIO;
 use CycloneDX\Composer\Builders\BomBuilder;

--- a/tests/MakeBom/FactoryTest.php
+++ b/tests/MakeBom/FactoryTest.php
@@ -21,7 +21,7 @@ declare(strict_types=1);
  * Copyright (c) Steve Springett. All Rights Reserved.
  */
 
-namespace Tests\MakeBom;
+namespace CycloneDX\Tests\MakeBom;
 
 use Composer\Composer;
 use Composer\Factory as ComposerFactory;

--- a/tests/MakeBom/OptionsTest.php
+++ b/tests/MakeBom/OptionsTest.php
@@ -21,7 +21,7 @@ declare(strict_types=1);
  * Copyright (c) Steve Springett. All Rights Reserved.
  */
 
-namespace Tests\MakeBom;
+namespace CycloneDX\Tests\MakeBom;
 
 use CycloneDX\Composer\Factories\SpecFactory;
 use CycloneDX\Composer\MakeBom\Exceptions\ValueError;

--- a/tests/PluginTest.php
+++ b/tests/PluginTest.php
@@ -21,7 +21,7 @@ declare(strict_types=1);
  * Copyright (c) Steve Springett. All Rights Reserved.
  */
 
-namespace Tests;
+namespace CycloneDX\Tests;
 
 use Composer\Plugin\Capability\CommandProvider;
 use Composer\Plugin\Capable;

--- a/tests/ToolUpdaterTest.php
+++ b/tests/ToolUpdaterTest.php
@@ -21,7 +21,7 @@ declare(strict_types=1);
  * Copyright (c) Steve Springett. All Rights Reserved.
  */
 
-namespace Tests;
+namespace CycloneDX\Tests;
 
 use Composer\Package\AliasPackage;
 use Composer\Package\PackageInterface;


### PR DESCRIPTION
so internal classes can be tested without warnings in CodeAnalysis.