### PR TITLE
make dev-tools php requirement clear

### DIFF
--- a/tools/composer-normalize/composer.json
+++ b/tools/composer-normalize/composer.json
@@ -2,6 +2,9 @@
     "name": "tools/composer-normalize",
     "type": "metapackage",
     "description": "composer-normalize",
+    "require": {
+        "php": ">=7.4"
+    },
     "require-dev": {
         "ergebnis/composer-normalize": "2.23.1",
         "roave/security-advisories": "dev-latest"

--- a/tools/composer-require-checker/composer.json
+++ b/tools/composer-require-checker/composer.json
@@ -2,6 +2,9 @@
     "name": "tools/composer-require-checker",
     "type": "metapackage",
     "description": "composer-require-checker",
+    "require": {
+        "php": ">=7.4"
+    },
     "require-dev": {
         "maglnet/composer-require-checker": "3.8.0",
         "roave/security-advisories": "dev-latest"

--- a/tools/composer-unused/composer.json
+++ b/tools/composer-unused/composer.json
@@ -2,6 +2,9 @@
     "name": "tools/composer-unused",
     "type": "metapackage",
     "description": "composer-unused",
+    "require": {
+        "php": ">=7.4"
+    },
     "require-dev": {
         "composer/composer": "^2.1.12",
         "icanhazstring/composer-unused": "0.8.0",

--- a/tools/php-cs-fixer/composer.json
+++ b/tools/php-cs-fixer/composer.json
@@ -2,6 +2,9 @@
     "name": "tools/php-cs-fixer",
     "type": "metapackage",
     "description": "php-cs-fixer",
+    "require": {
+        "php": ">=7.4"
+    },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "3.6.0",
         "roave/security-advisories": "dev-latest"

--- a/tools/psalm/composer.json
+++ b/tools/psalm/composer.json
@@ -2,6 +2,9 @@
     "name": "tools/psalm",
     "type": "metapackage",
     "description": "psalm and plugins",
+    "require": {
+        "php": ">=7.4"
+    },
     "require-dev": {
         "vimeo/psalm": "4.20.0",
         "roave/security-advisories": "dev-latest"


### PR DESCRIPTION
the `CONTRIBUTING.md` file states 
```md
The development-setup requires PHP >= 7.4,
even though the project might support PHP 7.3 on runtime.
```

to make the constraint clear, all tool's composer manifests were fixed to that fact