### PR TITLE
BC: drop deprecated command `make-bom`

### DIFF
--- a/.github/ISSUE_TEMPLATE/ValidationError-report.md
+++ b/.github/ISSUE_TEMPLATE/ValidationError-report.md
@@ -12,7 +12,7 @@ assignees: ''
 Steps to reproduce the behavior:
 
 1. How was _cyclonedx-php-composer_  called?
-   <!-- e.g. `composer make-bom --exclude-dev ...` -->
+   <!-- e.g. `composer CycloneDX:make-sbom --exclude-dev ...` -->
 2. What `composer.lock` file was processed?
    <!-- upload it to this issue, or a pastebin of you choice and put the link here. -->
 3. Error report:

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -143,7 +143,7 @@ jobs:
         if: ${{ ! matrix.stdout }}
         working-directory: ${{ env.DEMO_TOOL_PATH }}
         run: >
-          composer make-bom
+          composer CycloneDX:make-sbom
           -vvv
           $OMIT_RULES
           --spec-version=${{ matrix.spec-version }}
@@ -156,7 +156,7 @@ jobs:
         if: ${{ matrix.stdout }}
         working-directory: ${{ env.DEMO_TOOL_PATH }}
         run: >
-          composer make-bom
+          composer CycloneDX:make-sbom
           -vvv
           $OMIT_RULES
           --spec-version=${{ matrix.spec-version }}

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
   * Removed support for PHP `<8.1` (via [#250])
   * Removed support for Composer `<2.3` ([#153] via [#250])
   * CLI
+    * Removed deprecated composer command `make-bom`, call `composer CycloneDX:make-sbom` instead ([#293] via [#309])
     * Changed option `output-file` to default to `-` now, which causes to print to STDOUT (via [#250])
     * Removed option `exclude-dev` in favour of new option `omit` (via [#250])
     * Removed option `exclude-plugins` in favour of new option `omit` (via [#250])
@@ -45,6 +46,8 @@ All notable changes to this project will be documented in this file.
 [#250]: https://github.com/CycloneDX/cyclonedx-php-composer/pull/250
 [#261]: https://github.com/CycloneDX/cyclonedx-php-composer/issues/261
 [#279]: https://github.com/CycloneDX/cyclonedx-php-composer/issues/279
+[#293]: https://github.com/CycloneDX/cyclonedx-php-composer/issues/293
+[#309]: https://github.com/CycloneDX/cyclonedx-php-composer/pull/309
 
 
 ## 3.11.0 - 2023-02-11

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -46,11 +46,21 @@ All notable changes to this project will be documented in this file.
 [#261]: https://github.com/CycloneDX/cyclonedx-php-composer/issues/261
 [#279]: https://github.com/CycloneDX/cyclonedx-php-composer/issues/279
 
+
+## 3.11.0 - 2023-02-11
+
+* Changed
+  * CLI via `composer make-bom` became deprecated, use `composer CycloneDX:make-sbom` instead. ([#293] via [#308])  
+    The composer command `make-bom` will be removed in the next major version.
+
+[#293]: https://github.com/CycloneDX/cyclonedx-php-composer/issues/293
+[#308]: https://github.com/CycloneDX/cyclonedx-php-composer/pull/308
+
 ## 3.10.2 - 2022-09-15
 
 Maintenance Release.
 
-* Legal:
+* Legal
   * Transferred copyright to OWASP Foundation. (via [#244])
 
 [#244]: https://github.com/CycloneDX/cyclonedx-php-composer/pull/244

--- a/README.md
+++ b/README.md
@@ -43,15 +43,15 @@ composer require --dev cyclonedx/cyclonedx-php-composer
 
 ## Usage
 
-After successful installation, the composer command `make-bom` is available.
+After successful installation, the composer command `CycloneDX:make-sbom` is available.
 
 ```text
-$ composer make-bom --help
+$ composer CycloneDX:make-sbom --help
 Description:
   Generate a CycloneDX Bill of Materials from a PHP composer project.
 
 Usage:
-  make-bom [options] [--] [<composer-file>]
+  CycloneDX:make-sbom [options] [--] [<composer-file>]
 
 Arguments:
   composer-file                                       Path to composer config file.

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -68,7 +68,7 @@ class Plugin implements PluginInterface, Capable, CommandProvider
         return [
             new MakeBom\Command(
                 new MakeBom\Options(),
-                'make-bom'
+                'CycloneDX:make-sbom'
             ),
         ];
     }

--- a/tests/PluginTest.php
+++ b/tests/PluginTest.php
@@ -108,10 +108,15 @@ final class PluginTest extends TestCase
 
         self::assertContainsOnlyInstancesOf(\Composer\Command\BaseCommand::class, $commands);
 
-        self::assertCount(1, $commands);
-        $command = reset($commands);
+        self::assertCount(2, $commands);
+
+        $command = $commands[0];
         self::assertInstanceOf(Command::class, $command);
-        self::assertSame('make-bom', $command->getName());
+        self::assertSame('CycloneDX:make-sbom', $command->getName());
+
+        $commandDeprecated = $commands[1];
+        self::assertInstanceOf(Command::class, $commandDeprecated);
+        self::assertSame('make-bom', $commandDeprecated->getName());
     }
 
     #[\PHPUnit\Framework\Attributes\Depends('testPluginImplementsRequiredInterfaces')]

--- a/tests/PluginTest.php
+++ b/tests/PluginTest.php
@@ -108,15 +108,11 @@ final class PluginTest extends TestCase
 
         self::assertContainsOnlyInstancesOf(\Composer\Command\BaseCommand::class, $commands);
 
-        self::assertCount(2, $commands);
+        self::assertCount(1, $commands);
 
         $command = $commands[0];
         self::assertInstanceOf(Command::class, $command);
         self::assertSame('CycloneDX:make-sbom', $command->getName());
-
-        $commandDeprecated = $commands[1];
-        self::assertInstanceOf(Command::class, $commandDeprecated);
-        self::assertSame('make-bom', $commandDeprecated->getName());
     }
 
     #[\PHPUnit\Framework\Attributes\Depends('testPluginImplementsRequiredInterfaces')]


### PR DESCRIPTION
Supersedes #309, closes #309

fixes #293