### PR TITLE
chore: prevent type confusion

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,8 @@
     },
     "require-dev": {
         "composer/composer": "^2.3.0",
-        "roave/security-advisories": "dev-latest"
+        "roave/security-advisories": "dev-latest",
+        "symfony/console": "<7"
     },
     "prefer-stable": true,
     "autoload": {


### PR DESCRIPTION
`symfony/console` v7 introduced return types.
`composer` does not follow those, yet.
this causes errors: https://github.com/CycloneDX/cyclonedx-php-composer/actions/runs/7066431487/job/19238277833#step:9:19
```text
PHP Fatal error:  Declaration of Composer\Command\InitCommand::execute(Symfony\Component\Console\Input\InputInterface $input, Symfony\Component\Console\Output\OutputInterface $output) must be compatible with Symfony\Component\Console\Command\Command::execute(Symfony\Component\Console\Input\InputInterface $input, Symfony\Component\Console\Output\OutputInterface $output): int in /home/runner/work/cyclonedx-php-composer/cyclonedx-php-composer/vendor/composer/composer/src/Composer/Command/InitCommand.php on line 85
```



here is the workaound: dont use v7 of `symfony/console`