### PR TITLE
feat!: default to CDX1.5

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## unreleased
 
+* BREAKING changes
+  * CLI switch `--spec-version` defaults to `1.5`, was `1.4` (via [#])
+* Dependencies
+    * Raised dependency `cyclonedx/cyclonedx-library:^3.1`, was `:^2.3 || ^3.0` (via [#])
+
+[#]: 
+
 ## 4.2.3 - 2023-11-27
 
 * Misc
@@ -169,8 +176,8 @@ Maintenance Release.
 
 ## 3.10.0 - 2022-04-02
 
-* Changed
-  * Raised dependency `cyclonedx/cyclonedx-library:^1.4.2`, was `cyclonedx/cyclonedx-library:^1.3.1`. (via [#192])
+* Dependencies
+  * Raised dependency `cyclonedx/cyclonedx-library:^1.4.2`, was `:^1.3.1`. (via [#192])
 * Misc
   * Adjusted internal typing and typehints. (via [#192])
   * Improved compatibility to Composer v2.3 (via [#212])

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,11 +5,11 @@ All notable changes to this project will be documented in this file.
 ## unreleased
 
 * BREAKING changes
-  * CLI switch `--spec-version` defaults to `1.5`, was `1.4` (via [#])
+  * CLI switch `--spec-version` defaults to `1.5`, was `1.4` (via [#441])
 * Dependencies
-    * Raised dependency `cyclonedx/cyclonedx-library:^3.1`, was `:^2.3 || ^3.0` (via [#])
+    * Raised dependency `cyclonedx/cyclonedx-library:^3.1`, was `:^2.3 || ^3.0` (via [#441])
 
-[#]: 
+[#441]: https://github.com/CycloneDX/cyclonedx-php-composer/pull/441
 
 ## 4.2.3 - 2023-11-27
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Options:
       --omit=OMIT                                     Omit dependency types.
                                                       {choices: "dev", "plugin"} (multiple values allowed)
       --spec-version=SPEC-VERSION                     Which version of CycloneDX spec to use.
-                                                      {choices: "1.1", "1.2", "1.3", "1.4", "1.5"} [default: "1.4"]
+                                                      {choices: "1.1", "1.2", "1.3", "1.4", "1.5"} [default: "1.5"]
       --output-reproducible|--no-output-reproducible  Whether to go the extra mile and make the output reproducible.
                                                       This might result in loss of time- and random-based-values.
       --validate|--no-validate                        Formal validate the resulting BOM.

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     "require": {
         "php": "^8.1",
         "composer-plugin-api": "^2.3",
-        "cyclonedx/cyclonedx-library": "^2.3 || ^3.0",
+        "cyclonedx/cyclonedx-library": "^3.1",
         "package-url/packageurl-php": "^1.0"
     },
     "require-dev": {

--- a/demo/local/results/bom.1.2.json
+++ b/demo/local/results/bom.1.2.json
@@ -94,7 +94,7 @@
                 },
                 {
                     "type": "issue-tracker",
-                    "url": "https://pear.php.net/bugs/search.php?cmd=display&package_name[]=PEAR_Exception",
+                    "url": "https://pear.php.net/bugs/search.php?cmd=display&package_name%5B%5D=PEAR_Exception",
                     "comment": "as detected from Composer manifest 'support.issues'"
                 }
             ]

--- a/demo/local/results/bom.1.3.json
+++ b/demo/local/results/bom.1.3.json
@@ -110,7 +110,7 @@
                 },
                 {
                     "type": "issue-tracker",
-                    "url": "https://pear.php.net/bugs/search.php?cmd=display&package_name[]=PEAR_Exception",
+                    "url": "https://pear.php.net/bugs/search.php?cmd=display&package_name%5B%5D=PEAR_Exception",
                     "comment": "as detected from Composer manifest 'support.issues'"
                 }
             ],

--- a/demo/local/results/bom.1.4.json
+++ b/demo/local/results/bom.1.4.json
@@ -110,7 +110,7 @@
                 },
                 {
                     "type": "issue-tracker",
-                    "url": "https://pear.php.net/bugs/search.php?cmd=display&package_name[]=PEAR_Exception",
+                    "url": "https://pear.php.net/bugs/search.php?cmd=display&package_name%5B%5D=PEAR_Exception",
                     "comment": "as detected from Composer manifest 'support.issues'"
                 }
             ],

--- a/demo/local/results/bom.1.5.json
+++ b/demo/local/results/bom.1.5.json
@@ -110,7 +110,7 @@
                 },
                 {
                     "type": "issue-tracker",
-                    "url": "https://pear.php.net/bugs/search.php?cmd=display&package_name[]=PEAR_Exception",
+                    "url": "https://pear.php.net/bugs/search.php?cmd=display&package_name%5B%5D=PEAR_Exception",
                     "comment": "as detected from Composer manifest 'support.issues'"
                 }
             ],

--- a/src/_internal/MakeBom/Options.php
+++ b/src/_internal/MakeBom/Options.php
@@ -100,9 +100,9 @@ class Options
      * @psalm-var array<string, Version>
      */
     private const VALUE_SPEC_VERSION_MAP = [
-        '1.4' => Version::v1dot4,
-        // first in list is the default value - see constructor
         '1.5' => Version::v1dot5,
+        // first in list is the default value - see constructor
+        '1.4' => Version::v1dot4,
         '1.3' => Version::v1dot3,
         '1.2' => Version::v1dot2,
         '1.1' => Version::v1dot1,

--- a/tests/Integration/CommandMakeSbomTest.php
+++ b/tests/Integration/CommandMakeSbomTest.php
@@ -61,14 +61,14 @@ final class CommandMakeSbomTest extends CommandTestCase
 
     public static function dp(): Generator
     {
-        yield 'not reproducible defaults to XML 1.4 with serialnumber' => [
+        yield 'not reproducible defaults to XML 1.5 with serialnumber' => [
             ['--output-reproducible' => false],
-            '<bom xmlns="http://cyclonedx.org/schema/bom/1.4" version="1" serialNumber="',
+            '<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1" serialNumber="',
         ];
-        yield 'reproducible defaults to XML 1.4 with no serial number nor timestamp' => [
+        yield 'reproducible defaults to XML 1.5 with no serial number nor timestamp' => [
             ['--output-reproducible' => true],
             <<<'XML'
-                <bom xmlns="http://cyclonedx.org/schema/bom/1.4" version="1">
+                <bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1">
                   <metadata>
                     <tools>
                 XML,

--- a/tests/Unit/MakeBom/OptionsTest.php
+++ b/tests/Unit/MakeBom/OptionsTest.php
@@ -62,7 +62,7 @@ final class OptionsTest extends TestCase
                 'outputFormat' => Format::XML,
                 'outputFile' => Options::VALUE_OUTPUT_FILE_STDOUT,
                 'omit' => [],
-                'specVersion' => Version::v1dot4,
+                'specVersion' => Version::v1dot5,
                 'validate' => true,
                 'mainComponentVersion' => null,
                 'composerFile' => null,


### PR DESCRIPTION
* BREAKING changes
  * CLI switch `--spec-version` defaults to `1.5`, was `1.4` 
* Dependencies
    * Raised dependency `cyclonedx/cyclonedx-library:^3.1`, was `:^2.3 || ^3.0`
