### PR TITLE
chore: re-enable `symfony/console:>=7` as dev-dep

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,8 +40,7 @@
     },
     "require-dev": {
         "composer/composer": "^2.3.0",
-        "roave/security-advisories": "dev-latest",
-        "symfony/console": "<7"
+        "roave/security-advisories": "dev-latest"
     },
     "prefer-stable": true,
     "autoload": {


### PR DESCRIPTION
Followup of #438