### PR TITLE
Add cooldown for dependency update checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
     schedule:
       interval: 'weekly'
       day: 'saturday'
+    cooldown:
+      default-days: 7
     allow:
       - dependency-type: 'all'
     versioning-strategy: 'auto'
@@ -22,6 +24,8 @@ updates:
     schedule:
       interval: 'weekly'
       day: 'saturday'
+    cooldown:
+      default-days: 7
     allow:
       - dependency-type: 'all'
     versioning-strategy: 'auto'
@@ -36,6 +40,8 @@ updates:
     schedule:
       interval: 'weekly'
       day: 'saturday'
+    cooldown:
+      default-days: 7
     allow:
       - dependency-type: 'all'
     versioning-strategy: 'auto'
@@ -50,6 +56,8 @@ updates:
     schedule:
       interval: 'weekly'
       day: 'saturday'
+    cooldown:
+      default-days: 7
     allow:
       - dependency-type: 'all'
     versioning-strategy: 'auto'
@@ -64,6 +72,8 @@ updates:
     schedule:
       interval: 'weekly'
       day: 'saturday'
+    cooldown:
+      default-days: 7
     allow:
       - dependency-type: 'all'
     versioning-strategy: 'auto'
@@ -78,6 +88,8 @@ updates:
     schedule:
       interval: 'weekly'
       day: 'saturday'
+    cooldown:
+      default-days: 7
     allow:
       - dependency-type: 'all'
     versioning-strategy: 'auto'
@@ -92,6 +104,8 @@ updates:
     schedule:
       interval: 'weekly'
       day: 'saturday'
+    cooldown:
+      default-days: 7
     allow:
       - dependency-type: 'all'
     versioning-strategy: 'auto'
@@ -107,6 +121,8 @@ updates:
     schedule:
       interval: 'weekly'
       day: 'saturday'
+    cooldown:
+      default-days: 7
     labels: [ 'dependencies', 'CI' ]
     commit-message:
       ## prefix maximum string length of 15


### PR DESCRIPTION



### Description

Added cooldown settings for dependency updates in Dependabot configuration.

### AI Tool Disclosure

- [x] My contribution does not include any AI-generated content
- [ ] My contribution includes AI-generated content, as disclosed below:
  - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie etc.]`
  - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro etc.]`
  - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/CycloneDX/cyclonedx-php-composer/blob/master/CONTRIBUTING.md) guidelines
