### PR TITLE
chore: install composer 2.9 for linting & type-checking

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -219,6 +219,9 @@ jobs:
       - name: Install (composer:~${{ matrix.composer }}.0 ${{ matrix.dependencies }})
         run: |
           # removing security-foo here is fine, as no code is run, only parsed
+          if ! composer config audit.block-insecure false; then
+            echo "Composer version does not support audit.block-insecure; continuing."
+          fi
           composer remove --dev 'roave/security-advisories' \
              --no-update --no-install
           composer update \


### PR DESCRIPTION

### Description

CI/CT fail to install composer 2.9.x for linting & type-checking

https://github.com/CycloneDX/cyclonedx-php-composer/actions/runs/30409857351/job/90443345986#step:7:28
```text
  Problem 1
    - Root composer.json requires composer/composer ^2.3.0, found composer/composer[2.3.0, ..., 2.10.2] but these were not loaded, because they are affected by security advisories ("PKSA-q3ht-3g42-rg8f", "PKSA-4pm6-g63v-5rkr", "PKSA-zcdk-qnhk-hq2g", "PKSA-pwvr-3754-v57r", "PKSA-t5r2-p5q9-mtpn", "PKSA-6bp1-9hfj-2cgv", "PKSA-1gck-s111-yq7g", "PKSA-s25b-vbmp-jvhh", "PKSA-b8f7-zn44-r4gz", "PKSA-jn72-4kr8-gj3h", "PKSA-m1ph-vmbx-2xd3", "PKSA-6zmq-d6mk-r5wm"). Go to https://packagist.org/security-advisories/ to find advisory details. To ignore the advisories, add them to the audit "ignore" config. To turn the feature off entirely, you can set "block-insecure" to false in your "audit" config.

Error: Your requirements could not be resolved to an installable set of packages.
```

lets ignore these vulnerable versions, as no code is executed, only parsed ...



### AI Tool Disclosure

- [x] My contribution does not include any AI-generated content
- [ ] My contribution includes AI-generated content, as disclosed below:
  - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie etc.]`
  - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro etc.]`
  - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/CycloneDX/cyclonedx-php-composer/blob/master/CONTRIBUTING.md) guidelines
